### PR TITLE
Lock down file permissions on CSI socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,9 +893,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
 name = "libgit2-sys"
@@ -1621,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
 dependencies = [
  "libc",
  "winapi",
@@ -1672,6 +1672,7 @@ dependencies = [
  "built",
  "clap",
  "futures",
+ "libc",
  "openssl",
  "pin-project",
  "prost",
@@ -1680,6 +1681,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "snafu",
+ "socket2",
  "stackable-operator",
  "time 0.3.5",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.52"
 async-trait = "0.1.52"
 clap = { version = "3.0.9", features = ["derive", "env"] }
 futures = "0.3.18"
+libc = "0.2.113"
 openssl = "0.10.38"
 pin-project = "1.0.8"
 prost = "0.9.0"
@@ -20,6 +21,7 @@ serde = "1.0.130"
 serde_json = "1.0.74"
 serde_yaml = "0.8.23"
 snafu = "0.7.0"
+socket2 = { version = "0.4.3", features = ["all"] }
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.8.0" }
 time = "0.3.5"
 tokio = { version = "1.14.0", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,12 +28,11 @@ use std::{
 use tokio::{
     fs::{create_dir_all, File},
     io::AsyncWriteExt,
-    net::UnixListener,
     signal::unix::{signal, SignalKind},
 };
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::{transport::Server, Request, Response, Status};
-use utils::TonicUnixStream;
+use utils::{uds_bind_private, TonicUnixStream};
 
 use crate::backend::{pod_info::PodInfo, SecretVolumeSelector};
 
@@ -392,7 +391,7 @@ async fn main() -> anyhow::Result<()> {
                 .add_service(IdentityServer::new(SecretProvisionerIdentity))
                 .add_service(NodeServer::new(SecretProvisionerNode { client }))
                 .serve_with_incoming_shutdown(
-                    UnixListenerStream::new(UnixListener::bind(csi_endpoint)?)
+                    UnixListenerStream::new(uds_bind_private(csi_endpoint)?)
                         .map_ok(TonicUnixStream),
                     sigterm.recv().map(|_| ()),
                 )

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -73,6 +73,9 @@ pub fn uds_bind_private(path: impl AsRef<Path>) -> Result<UnixListener, std::io:
     // Workaround for https://github.com/tokio-rs/tokio/issues/4422
     let socket = Socket::new(socket2::Domain::UNIX, socket2::Type::STREAM, None)?;
     unsafe {
+        // Socket-level chmod is propagated to the file created by Socket::bind.
+        // We need to chmod /before/ creating the file, because otherwise there is a brief window where
+        // the file is world-accessible (unless restricted by the global umask).
         if libc::fchmod(socket.as_raw_fd(), 0o600) == -1 {
             return Err(std::io::Error::last_os_error());
         }


### PR DESCRIPTION
Fixes #16

This is a bit more complicated than it ought to be, because neither Tokio nor std expose a proper API for this (see https://github.com/tokio-rs/tokio/issues/4422).