### PR TITLE
Lock down secret permissions, store secrets on tmpfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,6 +1683,7 @@ dependencies = [
  "snafu",
  "socket2",
  "stackable-operator",
+ "sys-mount",
  "time 0.3.5",
  "tokio",
  "tokio-stream",
@@ -1726,6 +1727,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "sys-mount"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777948089ea2ab5673e2062ff9818dd8ea9db04941f0ea9ab408b855858cc715"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde_yaml = "0.8.23"
 snafu = "0.7.0"
 socket2 = { version = "0.4.3", features = ["all"] }
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.8.0" }
+sys-mount = { version = "1.3.0", default-features = false }
 time = "0.3.5"
 tokio = { version = "1.14.0", features = ["full"] }
 tokio-stream = { version = "0.1.8", features = ["net"] }

--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,7 @@ rec {
   dockerImage = pkgs.dockerTools.streamLayeredImage {
     name = "docker.stackable.tech/teozkr/secret-provisioner";
     tag = dockerTag;
+    contents = [ pkgs.bashInteractive pkgs.coreutils pkgs.util-linuxMinimal ];
     config = {
       Cmd = [ (build+"/bin/stackable-secret-operator") "run" ];
     };

--- a/deploy/helm/secret-operator/templates/csidriver.yaml
+++ b/deploy/helm/secret-operator/templates/csidriver.yaml
@@ -6,5 +6,6 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: true
+  fsGroupPolicy: File
   volumeLifecycleModes:
   - Ephemeral

--- a/deploy/helm/secret-operator/templates/daemonset.yaml
+++ b/deploy/helm/secret-operator/templates/daemonset.yaml
@@ -41,6 +41,7 @@ spec:
               mountPath: /csi
             - name: mountpoint
               mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
         - name: node-driver-registrar
           image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
           args:

--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -25,6 +25,7 @@ podSecurityContext: {}
 securityContext:
   # secret-operator requires root permissions
   runAsUser: 0
+  privileged: true
   # capabilities:
   #   drop:
   #   - ALL

--- a/example-consumer-nginx.yaml
+++ b/example-consumer-nginx.yaml
@@ -20,7 +20,6 @@ spec:
         - -c
         - |
           cat /secret/tls.crt /secret/ca.crt > /secret/tls-merged.crt
-          chown 0:1000 /secret/tls-merged.crt
           chmod 640 /secret/tls-merged.crt
         volumeMounts:
         - name: secret
@@ -52,8 +51,6 @@ spec:
         - name: tmp
           mountPath: /var/run
       terminationGracePeriodSeconds: 1
-      securityContext:
-        fsGroup: 1000
       volumes:
       - name: secret
         csi:

--- a/example-consumer-nginx.yaml
+++ b/example-consumer-nginx.yaml
@@ -13,12 +13,15 @@ spec:
         app: secret-consumer-nginx
     spec:
       initContainers:
-      - name: merger
+      - name: prepare
         image: alpine
         args:
         - sh
         - -c
-        - cat /secret/tls.crt /secret/ca.crt > /secret/tls-merged.crt
+        - |
+          cat /secret/tls.crt /secret/ca.crt > /secret/tls-merged.crt
+          chown 0:1000 /secret/tls-merged.crt
+          chmod 640 /secret/tls-merged.crt
         volumeMounts:
         - name: secret
           mountPath: /secret
@@ -27,22 +30,30 @@ spec:
         image: nginx
         # args:
         # - bash
-        # tty: true
-        # stdin: true
+        tty: true
+        stdin: true
         # - nginx-debug
         # - -g
         # - 'daemon off;'
         # - -g
         # - 'error_log /foo debug;'
+        securityContext:
+          runAsUser: 1000
         ports:
         - name: https
-          containerPort: 443
+          containerPort: 8443
         volumeMounts:
         - name: secret
           mountPath: /secret
         - name: config
           mountPath: /etc/nginx/conf.d
+        - name: cache
+          mountPath: /var/cache/nginx
+        - name: tmp
+          mountPath: /var/run
       terminationGracePeriodSeconds: 1
+      securityContext:
+        fsGroup: 1000
       volumes:
       - name: secret
         csi:
@@ -53,6 +64,10 @@ spec:
       - name: config
         configMap:
           name: secret-consumer-nginx-config
+      - name: cache
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: Service
@@ -65,6 +80,7 @@ spec:
   ports:
   - name: https
     port: 443
+    targetPort: https
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -73,7 +89,7 @@ metadata:
 data:
   default.conf: |
     server {
-      listen 443 ssl http2;
+      listen 8443 ssl http2;
       ssl_certificate /secret/tls-merged.crt;
       ssl_certificate_key /secret/tls.key;
 

--- a/provisioner.yaml
+++ b/provisioner.yaml
@@ -15,10 +15,8 @@ spec:
       - name: provisioner
         image: docker.stackable.tech/teozkr/secret-provisioner
         imagePullPolicy: IfNotPresent
-        # Currently just a placeholder
-        # image: archlinux
-        # stdin: true
-        # tty: true
+        securityContext:
+          privileged: true
         env:
         - name: CSI_ENDPOINT
           value: /csi/csi.sock
@@ -27,6 +25,7 @@ spec:
           mountPath: /csi
         - name: mountpoint
           mountPath: /var/lib/kubelet/pods
+          mountPropagation: Bidirectional
       - name: node-driver-registrar
         # image: csi-node-driver-registrar
         # imagePullPolicy: IfNotPresent
@@ -104,6 +103,7 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: true
+  fsGroupPolicy: File
   tokenRequests:
   - audience: secrets.stackable.tech/consumer
   volumeLifecycleModes:


### PR DESCRIPTION
## Description

This should help reduce outside access, and start making an effort to avoid storing sensitive material on disk at all where viable.

### Caveats

- Existing `Pod`s mounting secret volumes will get stuck Terminating when deleted, until the Kubelet is restarted, or the folder is deleted manually (see Kubelet logs for more details)
  - This is a one-time migration due to how this PR changes volume cleanup
- You may need to set `Pod.spec.securityContext.fsGroup` to give your pod permission to access the secrets, depending on how you drop permissions

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
