### PR TITLE
[Merged by Bors] - Convert CSI listener socket back to non-blocking mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ All notable changes to this project will be documented in this file.
 - Store secrets on tmpfs ([#37]).
 - Locked down secret permissions by default ([#37]).
 
+### Bugfixes
+- Fixed thread starvation and slow shutdowns ([#47]).
+
 [#37]: https://github.com/stackabletech/secret-operator/pull/37
+[#47]: https://github.com/stackabletech/secret-operator/pull/47
 
 ## [0.1.0] - 2022-02-03
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -82,5 +82,6 @@ pub fn uds_bind_private(path: impl AsRef<Path>) -> Result<UnixListener, std::io:
     }
     socket.bind(&socket2::SockAddr::unix(path)?)?;
     socket.listen(1024)?;
+    socket.set_nonblocking(true)?;
     UnixListener::from_std(socket.into())
 }


### PR DESCRIPTION
## Description

Fixes #45

This was a regression in #26, causing both slow shutdowns and general thread
starvation that could cause the operator to hang entirely in single-core environments.

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
