### PR TITLE
[Merged by Bors] - Run secret-operator as root when deployed by Helm

### DIFF
--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -23,6 +23,8 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  # secret-operator requires root permissions
+  runAsUser: 0
   privileged: true
   # capabilities:
   #   drop:

--- a/deploy/manifests/daemonset.yaml
+++ b/deploy/manifests/daemonset.yaml
@@ -24,6 +24,7 @@ spec:
         - name: secret-operator
           securityContext:
             privileged: true
+            runAsUser: 0
           image: "docker.stackable.tech/stackable/secret-operator:0.3.0-nightly"
           imagePullPolicy: IfNotPresent
           resources: {}


### PR DESCRIPTION


## Description

This seems to have been another value accidentally removed by the templating scripts

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
