### PR TITLE
[Merged by Bors] - Remove `secretLabels` option from `k8sSearch` backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- autoTls CA generation now requires opt-in ([#77]).
+- `autoTls` CA generation now requires opt-in ([#77]).
   - The default `tls` `SecretClass` now has this opt-in by default.
+  
+### Removed
+
+- `k8sSearch` backend's option `secretLabels` has been removed ([#123]).
 
 [#77]: https://github.com/stackabletech/secret-operator/pull/77
 [#114]: https://github.com/stackabletech/secret-operator/pull/114
+[#123]: https://github.com/stackabletech/secret-operator/pull/123
 [commons-#20]: https://github.com/stackabletech/commons-operator/pull/20
 
 ## [0.2.0] - 2022-02-14

--- a/deploy/helm/secret-operator/crds/crds.yaml
+++ b/deploy/helm/secret-operator/crds/crds.yaml
@@ -68,11 +68,6 @@ spec:
                             pod:
                               type: object
                           type: object
-                        secretLabels:
-                          additionalProperties:
-                            type: string
-                          default: {}
-                          type: object
                       required:
                         - searchNamespace
                       type: object

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -69,11 +69,6 @@ spec:
                             pod:
                               type: object
                           type: object
-                        secretLabels:
-                          additionalProperties:
-                            type: string
-                          default: {}
-                          type: object
                       required:
                         - searchNamespace
                       type: object

--- a/docs/modules/ROOT/examples/secretclass-tls.yaml
+++ b/docs/modules/ROOT/examples/secretclass-tls.yaml
@@ -17,5 +17,3 @@ spec:
         pod: {}
         # or...
         name: my-namespace
-      secretLabels:
-        type: custom-secret

--- a/docs/modules/ROOT/pages/secretclass.adoc
+++ b/docs/modules/ROOT/pages/secretclass.adoc
@@ -79,8 +79,6 @@ spec:
         pod: {}
         # or...
         name: my-namespace
-      secretLabels:
-        type: custom-secret
 ----
 
 `k8sSearch`:: Declares that the `k8sSearch` backend is used.
@@ -89,7 +87,6 @@ spec:
                                   for secrets that are provisioned by the application administrator.
 `k8sSearch.searchNamespace.name`:: The `Secret` objects are located in a single global namespace. Should be used for secrets
                                    that are provisioned by the cluster administrator.
-`k8sSearch.secretLabels`:: Extra labels that are required for a `Secret` to be bound.
 
 [#format]
 == Format

--- a/examples/simple-consumer-shell.yaml
+++ b/examples/simple-consumer-shell.yaml
@@ -43,8 +43,6 @@ spec:
     k8sSearch:
       searchNamespace:
         pod: {}
-      secretLabels:
-        type: custom-secret
 ---
 # A Secret that matches SecretClass/secret, for the Node kind-control-plane
 apiVersion: v1

--- a/rust/operator-binary/src/backend/dynamic.rs
+++ b/rust/operator-binary/src/backend/dynamic.rs
@@ -68,14 +68,12 @@ pub async fn from_class(
     class: SecretClass,
 ) -> Result<Box<Dynamic>, FromClassError> {
     Ok(match class.spec.backend {
-        crd::SecretClassBackend::K8sSearch(crd::K8sSearchBackend {
-            search_namespace,
-            secret_labels,
-        }) => from(super::K8sSearch {
-            client: client.clone(),
-            search_namespace,
-            secret_labels,
-        }),
+        crd::SecretClassBackend::K8sSearch(crd::K8sSearchBackend { search_namespace }) => {
+            from(super::K8sSearch {
+                client: client.clone(),
+                search_namespace,
+            })
+        }
         crd::SecretClassBackend::AutoTls(crd::AutoTlsBackend {
             ca:
                 crd::AutoTlsCa {

--- a/rust/operator-binary/src/backend/k8s_search.rs
+++ b/rust/operator-binary/src/backend/k8s_search.rs
@@ -43,7 +43,6 @@ impl SecretBackendError for Error {
 pub struct K8sSearch {
     pub client: stackable_operator::client::Client,
     pub search_namespace: SearchNamespace,
-    pub secret_labels: BTreeMap<String, String>,
 }
 
 #[async_trait]
@@ -55,11 +54,10 @@ impl SecretBackend for K8sSearch {
         selector: &SecretVolumeSelector,
         pod_info: PodInfo,
     ) -> Result<SecretContents, Self::Error> {
-        let mut label_selector = self.secret_labels.clone();
-        label_selector.insert(
+        let mut label_selector = BTreeMap::from([(
             "secrets.stackable.tech/class".to_string(),
             selector.class.to_string(),
-        );
+        )]);
         for scope in &selector.scope {
             match scope {
                 SecretScope::Node => {

--- a/rust/operator-binary/src/crd.rs
+++ b/rust/operator-binary/src/crd.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use serde::{Deserialize, Serialize};
 use stackable_operator::k8s_openapi::api::core::v1::SecretReference;
 use stackable_operator::kube::CustomResource;
@@ -32,8 +30,6 @@ pub enum SecretClassBackend {
 #[serde(rename_all = "camelCase")]
 pub struct K8sSearchBackend {
     pub search_namespace: SearchNamespace,
-    #[serde(default)]
-    pub secret_labels: BTreeMap<String, String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]


### PR DESCRIPTION
## Description

This never had any real purpose, since we always add the name of the `SecretClass` as a required label anyway.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
