### PR TITLE
[Merged by Bors] - fix: Downgrade h2 to our patched version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,9 +604,8 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+version = "0.3.7"
+source = "git+https://github.com/stackabletech/h2.git?branch=feature/grpc-uds#b7554e1b8730af5fbb7fc1841d92f9247c4e477c"
 dependencies = [
  "bytes",
  "fnv",
@@ -617,7 +616,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -2491,8 +2490,3 @@ name = "zeroize"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
-
-[[patch.unused]]
-name = "h2"
-version = "0.3.7"
-source = "git+https://github.com/stackabletech/h2.git?branch=feature/grpc-uds#b7554e1b8730af5fbb7fc1841d92f9247c4e477c"

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -31,8 +31,7 @@ tonic = "0.7.2"
 tonic-reflection = "0.4.0"
 tracing = "0.1.35"
 
-# Need to keep this in sync with our patched h2 build
-h2 = "=0.3.13"
+h2 = "=0.3.7" # Need to keep this in sync with our patched h2 build
 uuid = { version = "1.1.1", features = ["v4"] }
 
 [dev-dependencies]


### PR DESCRIPTION
# Description

As it broke the nightly build.
Put the comment inline so it may get recognized when renovate bot strikes again.
We could exclude it via `renovate.json` but operator-templating want's to overwrite it

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
