### PR TITLE
Make kubelet dir configurable (fixes #229)

### DIFF
--- a/deploy/helm/secret-operator/templates/daemonset.yaml
+++ b/deploy/helm/secret-operator/templates/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
             - name: csi
               mountPath: /csi
             - name: mountpoint
-              mountPath: /var/lib/kubelet/pods
+              mountPath: {{ .Values.kubeletDir }}/pods
               mountPropagation: Bidirectional
         - name: external-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
@@ -60,7 +60,7 @@ spec:
           image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
           args:
             - --csi-address=/csi/csi.sock
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/secrets.stackable.tech/csi.sock
+            - --kubelet-registration-path={{ .Values.kubeletDir }}/plugins/secrets.stackable.tech/csi.sock
           volumeMounts:
             - name: registration-sock
               mountPath: /registration
@@ -71,13 +71,13 @@ spec:
           hostPath:
             # node-driver-registrar appends a driver-unique filename to this path to avoid conflicts
             # see https://github.com/stackabletech/secret-operator/issues/229 for why this path should not be too long
-            path: /var/lib/kubelet/plugins_registry
+            path: {{ .Values.kubeletDir }}/plugins_registry
         - name: csi
           hostPath:
-            path: /var/lib/kubelet/plugins/secrets.stackable.tech/
+            path: {{ .Values.kubeletDir }}/plugins/secrets.stackable.tech/
         - name: mountpoint
           hostPath:
-            path: /var/lib/kubelet/pods/
+            path: {{ .Values.kubeletDir }}/pods/
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -50,3 +50,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Kubelet dir may vary in environments such as microk8s, see https://github.com/stackabletech/secret-operator/issues/229
+kubeletDir: /var/lib/kubelet


### PR DESCRIPTION
# Description

This should fix #229 from secret-operator's perspective. There are still outstanding issues in zk-op that I'll open a new issue for.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
