### PR TITLE
[Merged by Bors] - Allow configuring CSI docker images

### DIFF
--- a/deploy/helm/secret-operator/templates/daemonset.yaml
+++ b/deploy/helm/secret-operator/templates/daemonset.yaml
@@ -48,7 +48,8 @@ spec:
               mountPath: {{ .Values.kubeletDir }}/pods
               mountPropagation: Bidirectional
         - name: external-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+          image: "{{ .Values.csiProvisionerImage.repository }}:{{ .Values.csiProvisionerImage.tag }}"
+          imagePullPolicy: {{ .Values.csiProvisionerImage.pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
             - --feature-gates=Topology=true
@@ -57,7 +58,8 @@ spec:
             - name: csi
               mountPath: /csi
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
+          image: "{{ .Values.csiNodeDriverRegistrarImage.repository }}:{{ .Values.csiNodeDriverRegistrarImage.tag }}"
+          imagePullPolicy: {{ .Values.csiNodeDriverRegistrarImage.pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path={{ .Values.kubeletDir }}/plugins/secrets.stackable.tech/csi.sock

--- a/deploy/helm/secret-operator/templates/daemonset.yaml
+++ b/deploy/helm/secret-operator/templates/daemonset.yaml
@@ -48,8 +48,8 @@ spec:
               mountPath: {{ .Values.kubeletDir }}/pods
               mountPropagation: Bidirectional
         - name: external-provisioner
-          image: "{{ .Values.csiProvisionerImage.repository }}:{{ .Values.csiProvisionerImage.tag }}"
-          imagePullPolicy: {{ .Values.csiProvisionerImage.pullPolicy }}
+          image: "{{ .Values.csiProvisioner.image.repository }}:{{ .Values.csiProvisioner.image.tag }}"
+          imagePullPolicy: {{ .Values.csiProvisioner.image.pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
             - --feature-gates=Topology=true
@@ -58,8 +58,8 @@ spec:
             - name: csi
               mountPath: /csi
         - name: node-driver-registrar
-          image: "{{ .Values.csiNodeDriverRegistrarImage.repository }}:{{ .Values.csiNodeDriverRegistrarImage.tag }}"
-          imagePullPolicy: {{ .Values.csiNodeDriverRegistrarImage.pullPolicy }}
+          image: "{{ .Values.csiNodeDriverRegistrar.image.repository }}:{{ .Values.csiNodeDriverRegistrar.image.tag }}"
+          imagePullPolicy: {{ .Values.csiNodeDriverRegistrar.image.pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path={{ .Values.kubeletDir }}/plugins/secrets.stackable.tech/csi.sock

--- a/deploy/helm/secret-operator/templates/roles.yaml
+++ b/deploy/helm/secret-operator/templates/roles.yaml
@@ -14,6 +14,7 @@ rules:
       - list
       - watch
       - create
+      - patch
   - apiGroups:
       - ""
     resources:

--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -4,11 +4,11 @@ image:
   repository: docker.stackable.tech/stackable/secret-operator
   pullPolicy: IfNotPresent
 csiProvisionerImage:
-  repository: docker.stackable.tech/sig-storage/csi-provisioner
+  repository: docker.stackable.tech/k8s/sig-storage/csi-provisioner
   tag: v3.1.0
   pullPolicy: IfNotPresent
 csiNodeDriverRegistrarImage:
-  repository: docker.stackable.tech/sig-storage/csi-node-driver-registrar
+  repository: docker.stackable.tech/k8s/sig-storage/csi-node-driver-registrar
   tag: v2.5.0
   pullPolicy: IfNotPresent
 

--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -3,14 +3,16 @@
 image:
   repository: docker.stackable.tech/stackable/secret-operator
   pullPolicy: IfNotPresent
-csiProvisionerImage:
-  repository: docker.stackable.tech/k8s/sig-storage/csi-provisioner
-  tag: v3.1.0
-  pullPolicy: IfNotPresent
-csiNodeDriverRegistrarImage:
-  repository: docker.stackable.tech/k8s/sig-storage/csi-node-driver-registrar
-  tag: v2.5.0
-  pullPolicy: IfNotPresent
+csiProvisioner:
+  image:
+    repository: docker.stackable.tech/k8s/sig-storage/csi-provisioner
+    tag: v3.1.0
+    pullPolicy: IfNotPresent
+csiNodeDriverRegistrar:
+  image:
+    repository: docker.stackable.tech/k8s/sig-storage/csi-node-driver-registrar
+    tag: v2.5.0
+    pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""

--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -3,6 +3,14 @@
 image:
   repository: docker.stackable.tech/stackable/secret-operator
   pullPolicy: IfNotPresent
+csiProvisionerImage:
+  repository: docker.stackable.tech/sig-storage/csi-provisioner
+  tag: v3.1.0
+  pullPolicy: IfNotPresent
+csiNodeDriverRegistrarImage:
+  repository: docker.stackable.tech/sig-storage/csi-node-driver-registrar
+  tag: v2.5.0
+  pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
# Description

Additional things:

* Mirrored images to our registry
* Bumped `csi-node-driver-registrar` 2.4.0 -> 2.5.0
* Fixed `User "system:serviceaccount:default:secret-operator-serviceaccount" cannot patch resource "events" i
n API group "" in the namespace "default"`

Tested version `secret=0.7.0-pr235` in kind

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
