### PR TITLE
[Merged by Bors] - Implement unprivileged mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added `kerberosKeytab` provisioner backend ([#99]).
+- Added experimental unprivileged mode ([#252]).
 
 ### Changed
 
@@ -20,6 +21,7 @@ All notable changes to this project will be documented in this file.
 [#99]: https://github.com/stackabletech/secret-operator/pull/99
 [#231]: https://github.com/stackabletech/secret-operator/pull/231
 [#232]: https://github.com/stackabletech/secret-operator/pull/232
+[#252]: https://github.com/stackabletech/secret-operator/pull/252
 
 ## [23.1.0] - 2023-01-23
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -29,6 +29,8 @@ helm_crds, helm_non_crds = filter_yaml(
       name=operator_name,
       set=[
          'image.repository=' + registry + '/' + operator_name,
+         # Uncomment to enable unprivileged mode
+         'securityContext.privileged=false',
       ],
    ),
    api_version = "^apiextensions\\.k8s\\.io/.*$",

--- a/deploy/helm/secret-operator/templates/daemonset.yaml
+++ b/deploy/helm/secret-operator/templates/daemonset.yaml
@@ -41,12 +41,16 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            - name: PRIVILEGED
+              value: {{ .Values.securityContext.privileged | quote }}
           volumeMounts:
             - name: csi
               mountPath: /csi
             - name: mountpoint
               mountPath: {{ .Values.kubeletDir }}/pods
+              {{- if .Values.securityContext.privileged }}
               mountPropagation: Bidirectional
+              {{- end }}
             - name: tmp
               mountPath: /tmp
         - name: external-provisioner

--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -35,6 +35,9 @@ podSecurityContext: {}
 securityContext:
   # secret-operator requires root permissions
   runAsUser: 0
+  # It is strongly recommended to run secret-operator as a privileged container, since
+  # it enables additional protections for the secret contents.
+  # Unprivileged mode is EXPERIMENTAL and requires manual migration for an existing cluster.
   privileged: true
   # capabilities:
   #   drop:

--- a/rust/operator-binary/src/csi_server/node.rs
+++ b/rust/operator-binary/src/csi_server/node.rs
@@ -134,6 +134,7 @@ impl From<UnpublishError> for Status {
 pub struct SecretProvisionerNode {
     pub client: stackable_operator::client::Client,
     pub node_name: String,
+    pub privileged: bool,
 }
 
 impl SecretProvisionerNode {
@@ -158,14 +159,18 @@ impl SecretProvisionerNode {
                 _ => return Err(err).context(publish_error::CreateDirSnafu { path: target_path }),
             },
         }
-        Mount::new(
-            "",
-            target_path,
-            "tmpfs",
-            MountFlags::NODEV | MountFlags::NOEXEC | MountFlags::NOSUID,
-            None,
-        )
-        .context(publish_error::MountSnafu { path: target_path })?;
+        if self.privileged {
+            Mount::new(
+                "",
+                target_path,
+                "tmpfs",
+                MountFlags::NODEV | MountFlags::NOEXEC | MountFlags::NOSUID,
+                None,
+            )
+            .context(publish_error::MountSnafu { path: target_path })?;
+        } else {
+            tracing::info!("running in unprivileged mode, not creating mount for secret volume");
+        }
         // User: root/secret-operator
         // Group: Controlled by Pod.securityContext.fsGroup, the actual application
         // (when running as unprivileged user)
@@ -260,23 +265,37 @@ impl SecretProvisionerNode {
     }
 
     async fn clean_secret_dir(&self, target_path: &Path) -> Result<(), UnpublishError> {
-        match unmount(target_path, UnmountFlags::empty()) {
-            Ok(_) => {}
-            Err(err) => match err.kind() {
-                std::io::ErrorKind::NotFound => {
-                    tracing::warn!(volume.path = %target_path.display(), "Tried to delete volume path that does not exist, assuming it was already deleted");
-                    return Ok(());
-                }
-                std::io::ErrorKind::InvalidInput => {
-                    tracing::warn!(volume.path = %target_path.display(), "Tried to unmount volume path that is not mounted, trying to delete it anyway");
-                }
-                _ => return Err(err).context(unpublish_error::UnmountSnafu { path: target_path }),
-            },
-        };
-        tokio::fs::remove_dir(&target_path)
-            .await
-            .context(unpublish_error::DeleteSnafu { path: target_path })?;
-        Ok(())
+        // unmount() fails unconditionally with PermissionDenied when running in an unprivileged container,
+        // even if it wouldn't be sensible to even try anyway (such as when there is no volume mount).
+        if self.privileged {
+            match unmount(target_path, UnmountFlags::empty()) {
+                Ok(_) => {}
+                Err(err) => match err.kind() {
+                    std::io::ErrorKind::NotFound => {
+                        tracing::warn!(volume.path = %target_path.display(), "Tried to unmount volume path that does not exist, assuming it was already deleted");
+                        return Ok(());
+                    }
+                    std::io::ErrorKind::InvalidInput => {
+                        tracing::warn!(volume.path = %target_path.display(), "Tried to unmount volume path that is not mounted, trying to delete it anyway");
+                    }
+                    _ => {
+                        return Err(err)
+                            .context(unpublish_error::UnmountSnafu { path: target_path })
+                    }
+                },
+            };
+        }
+        // There is no mount in unprivileged mode, so we need to remove all contents in that case.
+        // This may still apply to privileged mode, in case users are migrating from unprivileged to privileged mode.
+        match tokio::fs::remove_dir_all(&target_path).await {
+            Ok(_) => Ok(()),
+            // We already catch this above when running in privileged mode, but in unprivileged mode this is still possible
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                tracing::warn!(volume.path = %target_path.display(), "Tried to delete volume path that does not exist, assuming it was already deleted");
+                Ok(())
+            }
+            Err(err) => Err(err).context(unpublish_error::DeleteSnafu { path: target_path }),
+        }
     }
 }
 

--- a/rust/operator-binary/src/csi_server/node.rs
+++ b/rust/operator-binary/src/csi_server/node.rs
@@ -169,7 +169,7 @@ impl SecretProvisionerNode {
             )
             .context(publish_error::MountSnafu { path: target_path })?;
         } else {
-            tracing::info!("running in unprivileged mode, not creating mount for secret volume");
+            tracing::info!("Running in unprivileged mode, not creating mount for secret volume");
         }
         // User: root/secret-operator
         // Group: Controlled by Pod.securityContext.fsGroup, the actual application


### PR DESCRIPTION
# Description

This adds support for running as an unprivileged container (mostly fixes #243).

Sadly, it doesn't run rootless per se, since we need those privileges to register the CSI plugins, but it at least lets containerd/k8s keep some of its sandboxing.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
