### PR TITLE
[Merged by Bors] - Fix migrate-longer-csi-registration-path container runAsUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Shortened the registration socket path for Microk8s compatibility ([#231]).
-  - The old CSI registration path will be automatically migrated during upgrade ([#258]).
+  - The old CSI registration path will be automatically migrated during upgrade ([#258], [#260]).
   - You might need to manually remove `/var/lib/kubelet/plugins_registry/secrets.stackable.tech-reg.sock` when downgrading
 - Made kubeletDir configurable ([#232]).
   - Microk8s users will need to `--set kubeletDir=/var/snap/microk8s/common/var/lib/kubelet`.
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 [#252]: https://github.com/stackabletech/secret-operator/pull/252
 [#257]: https://github.com/stackabletech/secret-operator/pull/257
 [#258]: https://github.com/stackabletech/secret-operator/pull/258
+[#260]: https://github.com/stackabletech/secret-operator/pull/260
 
 ## [23.1.0] - 2023-01-23
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -30,7 +30,7 @@ helm_crds, helm_non_crds = filter_yaml(
       set=[
          'image.repository=' + registry + '/' + operator_name,
          # Uncomment to enable unprivileged mode
-         'securityContext.privileged=false',
+         # 'securityContext.privileged=false',
       ],
    ),
    api_version = "^apiextensions\\.k8s\\.io/.*$",

--- a/deploy/helm/secret-operator/templates/daemonset.yaml
+++ b/deploy/helm/secret-operator/templates/daemonset.yaml
@@ -97,6 +97,8 @@ spec:
           volumeMounts:
             - name: registration-sock
               mountPath: /registration
+          securityContext:
+            runAsUser: 0
       volumes:
         - name: registration-sock
           hostPath:


### PR DESCRIPTION
# Description

Noticed this during `stackablectl operator install secret`.
Strangely this doesn't happen when installing via Tilt...

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
