### PR TITLE
[Merged by Bors] - Fix missing escape in docs

### DIFF
--- a/docs/modules/secret-operator/pages/secretclass.adoc
+++ b/docs/modules/secret-operator/pages/secretclass.adoc
@@ -109,8 +109,8 @@ spec:
 `kerberosKeytab.admin.activeDirectory.ldapServer`:: An AD LDAP server, such as the AD Domain Controller. This _must_ match the server's FQDN, or GSSAPI authentication will fail.
 `kerberosKeytab.admin.activeDirectory.ldapTlsCaSecret`:: Reference (`name` and `namespace`) to a K8s `Secret` object containing the TLS CA (in `ca.crt`) that the LDAP server's certificate should be authenticated against.
 `kerberosKeytab.admin.activeDirectory.passwordCacheSecret`:: Reference (`name` and `namespace`) to a K8s `Secret` object where workload passwords will be stored. This _must not_ be accessible to end users.
-`kerberosKeytab.admin.activeDirectory.userDistinguishedName`:: The root Distinguished Name (DN) where service accounts should be provisioned, typically `CN=Users,{domain_dn}`.
-`kerberosKeytab.admin.activeDirectory.schemaDistinguishedName`:: The root Distinguished Name (DN) for AD-managed schemas, typically `CN=Schema,CN=Configuration,{domain_dn}`.
+`kerberosKeytab.admin.activeDirectory.userDistinguishedName`:: The root Distinguished Name (DN) where service accounts should be provisioned, typically `CN=Users,\{domain_dn\}`.
+`kerberosKeytab.admin.activeDirectory.schemaDistinguishedName`:: The root Distinguished Name (DN) for AD-managed schemas, typically `CN=Schema,CN=Configuration,\{domain_dn\}`.
 `kerberosKeytab.adminKeytabSecret`:: Reference (`name` and `namespace`) to a K8s `Secret` object where a keytab with administrative privileges is stored in the key `keytab`.
 `kerberosKeytab.adminPrincipal`:: The name of the Kerberos principal to be used by the Secret Operator. This should be provided by the Kerberos administrator. The credentials for this principal must be stored in the keytab (`adminKeytabSecret`).
 


### PR DESCRIPTION
# Description

Currently blocks docs site build

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
