### PR TITLE
[Merged by Bors] - krb5: Remove dummy key from keytab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `operator-rs` `0.27.1` -> `0.41.0` ([#275]).
+- Removed dummy key from generated Kerberos keytab ([#285]).
 
 [#275]: https://github.com/stackabletech/secret-operator/pull/275
+[#285]: https://github.com/stackabletech/secret-operator/pull/285
 
 ## [23.4.0] - 2023-04-17
 

--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,12 @@
       };
       krb5-sys = attrs: {
         nativeBuildInputs = [ pkgs.pkg-config ];
-        buildInputs = [ (pkgs.enableDebugging pkgs.krb5) ];
+        buildInputs = [ pkgs.krb5 ];
+        LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+        BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.clang.cc.lib}/lib/clang/${pkgs.lib.getVersion pkgs.clang.cc}/include";
+      };
+      libgssapi-sys = attrs: {
+        buildInputs = [ pkgs.krb5 ];
         LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
         BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.clang.cc.lib}/lib/clang/${pkgs.lib.getVersion pkgs.clang.cc}/include";
       };

--- a/rust/krb5/src/lib.rs
+++ b/rust/krb5/src/lib.rs
@@ -413,6 +413,23 @@ impl<'a> Keytab<'a> {
             )
         }
     }
+
+    /// Remove the specified key from the keytab.
+    pub fn remove(
+        &mut self,
+        principal: &Principal,
+        kvno: krb5_sys::krb5_kvno,
+    ) -> Result<(), Error> {
+        unsafe {
+            let mut entry: krb5_sys::krb5_keytab_entry = std::mem::zeroed();
+            entry.principal = principal.raw;
+            entry.vno = kvno;
+            Error::from_call_result(
+                Some(self.ctx),
+                krb5_sys::krb5_kt_remove_entry(self.ctx.raw, self.raw, &mut entry),
+            )
+        }
+    }
 }
 impl Drop for Keytab<'_> {
     fn drop(&mut self) {


### PR DESCRIPTION
# Description

Fixes #283.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
