### PR TITLE
Use eval instead of yq in the integration tests to substitute the namespace

### DIFF
--- a/tests/templates/kuttl/kerberos-ad/01-install-secretclass.yaml
+++ b/tests/templates/kuttl/kerberos-ad/01-install-secretclass.yaml
@@ -2,7 +2,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - script: yq eval '.metadata.name = "kerberos-" + strenv(NAMESPACE) | .spec.backend.kerberosKeytab |= (.adminKeytabSecret.namespace = strenv(NAMESPACE) | .admin.activeDirectory.passwordCacheSecret.namespace = .adminKeytabSecret.namespace | .admin.activeDirectory.ldapTlsCaSecret.namespace = .adminKeytabSecret.namespace)' secretclass.yaml | kubectl apply -f-
+  - script: eval "echo \"$(cat secretclass.yaml)\"" | kubectl apply -f -
 ---
 apiVersion: v1
 kind: Secret

--- a/tests/templates/kuttl/kerberos-ad/secretclass.yaml
+++ b/tests/templates/kuttl/kerberos-ad/secretclass.yaml
@@ -1,9 +1,7 @@
-# must be applied by a command step, since the reference namespace depends on the (random) test namespace
 ---
 apiVersion: secrets.stackable.tech/v1alpha1
 kind: SecretClass
 metadata:
-  # overridden by yq
   name: kerberos-$NAMESPACE
 spec:
   backend:
@@ -16,16 +14,16 @@ spec:
           # You may need to set AD as your fallback DNS resolver in your Kube DNS Corefile
           ldapServer: sble-adds.sble.test
           ldapTlsCaSecret:
-            # namespace: default
             name: secret-operator-ad-ca
+            namespace: $NAMESPACE
           passwordCacheSecret:
-            # namespace: default
             name: secret-operator-ad-passwords
+            namespace: $NAMESPACE
           # Subfolder must be created manually, of type "msDS-ShadowPrincipalContainer"
           userDistinguishedName: CN=Stackable,CN=Users,DC=sble,DC=test
           schemaDistinguishedName: CN=Schema,CN=Configuration,DC=sble,DC=test
       adminKeytabSecret:
         # Created by AD administrator
-        # namespace: default
         name: secret-operator-keytab
+        namespace: $NAMESPACE
       adminPrincipal: stackable-secret-operator

--- a/tests/templates/kuttl/kerberos/01-install-kdc.yaml
+++ b/tests/templates/kuttl/kerberos/01-install-kdc.yaml
@@ -2,7 +2,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - script: yq eval '.metadata.name = "kerberos-" + strenv(NAMESPACE) | .spec.backend.kerberosKeytab |= (.adminKeytabSecret.namespace = strenv(NAMESPACE) | .kdc = "krb5-kdc." + strenv(NAMESPACE) + ".svc.cluster.local" | .admin.mit.kadminServer = .kdc)' secretclass.yaml | kubectl apply -f-
+  - script: eval "echo \"$(cat secretclass.yaml)\"" | kubectl apply -f -
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/kerberos/secretclass.yaml
+++ b/tests/templates/kuttl/kerberos/secretclass.yaml
@@ -1,19 +1,17 @@
-# must be applied by a command step, since the reference namespace depends on the (random) test namespace
 ---
 apiVersion: secrets.stackable.tech/v1alpha1
 kind: SecretClass
 metadata:
-  # overridden by yq
   name: kerberos-$NAMESPACE
 spec:
   backend:
     kerberosKeytab:
       realmName: CLUSTER.LOCAL
-      kdc: krb5-kdc
+      kdc: krb5-kdc.$NAMESPACE.svc.cluster.local
       admin:
         mit:
-          kadminServer: krb5-kdc
+          kadminServer: krb5-kdc.$NAMESPACE.svc.cluster.local
       adminKeytabSecret:
-        # namespace: default
         name: secret-operator-keytab
+        namespace: $NAMESPACE
       adminPrincipal: stackable-secret-operator


### PR DESCRIPTION
# Description

Use eval instead of yq in the integration tests to substitute the namespace.

yq is not installed on the test driver and the integration tests of all other operators use eval to substitute the namespace, so it makes sense to do the same for the secret-operator.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
