### PR TITLE
Set same password for truststore as for keystore

### DIFF
--- a/rust/operator-binary/src/format/convert.rs
+++ b/rust/operator-binary/src/format/convert.rs
@@ -75,18 +75,11 @@ pub fn convert_tls_to_pkcs12(
     })
 }
 
-// This function was copied from https://github.com/hjiayz/p12/blob/0b3b2e1a141c7c2384e85f3737dcc4d4ab4e8b9c/src/lib.rs#L723-L734
 fn bmp_string(s: &str) -> Vec<u8> {
-    let utf16: Vec<u16> = s.encode_utf16().collect();
-
-    let mut bytes = Vec::with_capacity(utf16.len() * 2 + 2);
-    for c in utf16 {
-        bytes.push((c / 256) as u8);
-        bytes.push((c % 256) as u8);
-    }
-    bytes.push(0x00);
-    bytes.push(0x00);
-    bytes
+    s.encode_utf16()
+        .chain([0]) // null-termination character
+        .flat_map(u16::to_be_bytes)
+        .collect()
 }
 
 fn pkcs12_truststore<'a>(

--- a/rust/operator-binary/src/format/convert.rs
+++ b/rust/operator-binary/src/format/convert.rs
@@ -75,6 +75,7 @@ pub fn convert_tls_to_pkcs12(
     })
 }
 
+// This function was copied from https://github.com/hjiayz/p12/blob/0b3b2e1a141c7c2384e85f3737dcc4d4ab4e8b9c/src/lib.rs#L723-L734
 fn bmp_string(s: &str) -> Vec<u8> {
     let utf16: Vec<u16> = s.encode_utf16().collect();
 


### PR DESCRIPTION
# Description

https://github.com/stackabletech/secret-operator/pull/314 only sets the password for the PKCS#12 keystore.

This PR sets the same password (taken from `secrets.stackable.tech/format.compatibility.tls-pkcs12.password`) for the truststore. NiFi for example requires a non-blank password for the provided PKCS#12 truststore: https://github.com/apache/nifi/blob/00dc79c633d3ef4a2e49a70d4fe6190f1cd61a2d/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/KeyStoreUtils.java#L365-L367

The bmp_string function was copied from here: https://github.com/hjiayz/p12/blob/0b3b2e1a141c7c2384e85f3737dcc4d4ab4e8b9c/src/lib.rs#L723


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
