### PR TITLE
Use correct listener class in integration tests

### DIFF
--- a/tests/templates/kuttl/listener/01-install-nginx.yaml
+++ b/tests/templates/kuttl/listener/01-install-nginx.yaml
@@ -49,7 +49,7 @@ spec:
   - metadata:
       name: listener
       annotations:
-        listeners.stackable.tech/listener-class: nodeport
+        listeners.stackable.tech/listener-class: external-unstable
     spec:
       accessModes:
       - ReadWriteMany


### PR DESCRIPTION
# Description

Use correct listener class in integration tests.

The default listener class `nodeport` was replaced with `external-stable`/`external-unstable` in stackabletech/listener-operator#117.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
