### PR TITLE
Fix whitespace control in README generation

### DIFF
--- a/.readme/README.md.j2
+++ b/.readme/README.md.j2
@@ -4,11 +4,22 @@
 {%- set related_reading_links=[] -%}
 {%- set no_jenkins_job_badge=true -%}
 
-{% include "partials/borrowed/header.md.j2" %}
-{% include "partials/borrowed/links.md.j2" %}
+{% filter trim %}
+  {%- include "partials/borrowed/header.md.j2" -%}
+{% endfilter %}
 
-{% include "partials/main.md.j2" %}
+{% filter trim %}
+  {%- include "partials/borrowed/links.md.j2" -%}
+{% endfilter %}
 
-{% include "partials/borrowed/footer.md.j2" %}
+{% filter trim %}
+  {%- include "partials/main.md.j2" -%}
+{% endfilter %}
 
-{% include "partials/borrowed/related_reading.md.j2" %}
+{% filter trim %}
+  {%- include "partials/borrowed/footer.md.j2" -%}
+{% endfilter %}
+
+{% filter trim %}
+  {%- include "partials/borrowed/related_reading.md.j2" -%}
+{% endfilter %}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["rust/operator-binary", "rust/krb5", "rust/krb5-provision-keytab", "rust/krb5-sys"]
 default-members = ["rust/operator-binary"]
+resolver = "2"
 
 [workspace.package]
 version = "0.0.0-dev"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 <h1 align="center">Stackable Secret Operator</h1>
 
-
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/stackabletech/secret-operator/graphs/commit-activity)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://docs.stackable.tech/home/stable/contributor/index.html)
 [![License OSL3.0](https://img.shields.io/badge/license-OSL3.0-green)](./LICENSE)
@@ -48,7 +47,6 @@ The Secret Operator is deployed as a DaemonSet and provides a CSI to mount files
 
 The Secret Operator by [Stackable](https://stackable.tech/).
 This is a Kubernetes Operator to provision and inject secrets for Kubernetes Pods. It is part of the [Stackable Data Platform](https://stackable.tech/), a curated selection of the best open source data apps like Kafka, Druid, Trino or Spark, all working together seamlessly. Based on Kubernetes, it runs everywhere – on prem or in the cloud.
-
 
 ## About The Stackable Data Platform
 


### PR DESCRIPTION
# Description

So far we would include files with all their whitespace which can lead to markdownlint errors and inconsistencies. Now we trim everything we include.

This also switches to resolver v2 for the workspace because the render-readme step would warn about it.

Part of https://github.com/stackabletech/issues/issues/492