### PR TITLE
chore(docs): Remove explicit numbering from list

### DIFF
--- a/docs/modules/secret-operator/pages/secretclass.adoc
+++ b/docs/modules/secret-operator/pages/secretclass.adoc
@@ -44,15 +44,15 @@ annoying for others or fatal for products with a single point of failure and no 
 
 We have spent a considerate amount of time thinking about this issue and decided on the following compromises:
 
-1. To enforce security constraints, cluster administrators can set a maximum allowed certificate lifetime
-   on the SecretClass issuing the certificates (defaults to `15d`).
-2. We default to a certificate lifetime of `24h`.
-3. Pods consuming the certificate can request a longer lifetime or shutdown expiration buffer via annotations
-   on the xref:volume.adoc[Volume]. If they request a longer lifetime than the SecretClass allows,
-   it will be shortened to the maximum allowed lifetime.
-4. To avoid stampeding herds during restarts and spread out the load, certificate durations are lowered by up to 20%.
-4. The Pods will be evicted `6h` before the certificate expires, to ensure that no Pods are left running with expired secrets. Consumers can override this buffer using Volume annotations.
-   This buffer must be long enough that the product is guaranteed to gracefully shut down.
+. To enforce security constraints, cluster administrators can set a maximum allowed certificate lifetime
+  on the SecretClass issuing the certificates (defaults to `15d`).
+. We default to a certificate lifetime of `24h`.
+. Pods consuming the certificate can request a longer lifetime or shutdown expiration buffer via annotations
+  on the xref:volume.adoc[Volume]. If they request a longer lifetime than the SecretClass allows,
+  it will be shortened to the maximum allowed lifetime.
+. To avoid stampeding herds during restarts and spread out the load, certificate durations are lowered by up to 20%.
+. The Pods will be evicted `6h` before the certificate expires, to ensure that no Pods are left running with expired secrets. Consumers can override this buffer using Volume annotations.
+  This buffer must be long enough that the product is guaranteed to gracefully shut down.
 
 Most of our product operators will not set any specific certificate lifetime, so the default applies.
 In case an operator sets a higher lifetime, a tracking issue must be created to document and track the steps to reduce the certificate lifetime.


### PR DESCRIPTION
This fixes the break introduced in PR #361. It is caused by invalid numbering in an ordered list. See https://github.com/stackabletech/documentation/runs/21358715623.