### PR TITLE
Revert "Disable CA rotation by default for now"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 ## Changed
 
 - Use new annotation builder ([#341]).
-- `autoTLS` certificate authorities can now be rotated regularly ([#350], [#363]).
+- `autoTLS` certificate authorities will now be rotated regularly ([#350]).
   - [BREAKING] This changes the format of the CA secrets. Old secrets will be migrated automatically, but manual intervention will be required to downgrade back to 23.11.x.
 - `autoTLS` certificate authority lifetimes are now configurable ([#357]).
 - Certificate lifetimes are now jittered ([#361]).
@@ -23,7 +23,6 @@ All notable changes to this project will be documented in this file.
 [#352]: https://github.com/stackabletech/secret-operator/pull/352
 [#357]: https://github.com/stackabletech/secret-operator/pull/357
 [#361]: https://github.com/stackabletech/secret-operator/pull/361
-[#363]: https://github.com/stackabletech/secret-operator/pull/363
 
 
 ## [23.11.0] - 2023-11-24

--- a/deploy/helm/secret-operator/crds/crds.yaml
+++ b/deploy/helm/secret-operator/crds/crds.yaml
@@ -56,15 +56,6 @@ spec:
 
                                 If `autoGenerate: true` then the Secret Operator will prepare a new CA certificate the old CA approaches expiration. If `autoGenerate: false` then the Secret Operator will log a warning instead.
                               type: string
-                            experimentalRotateCaCertificate:
-                              default: false
-                              description: |-
-                                Whether the CA certificate should be rotated once the old certificate approaches expiration.
-
-                                This only takes effect when `autoGenerate: true`.
-
-                                This is an experimental option, that may be removed or changed in the future.
-                              type: boolean
                             secret:
                               description: Reference (name and namespace) to a Kubernetes Secret object where the CA certificate and key is stored in the keys `ca.crt` and `ca.key` respectively.
                               properties:

--- a/docs/modules/secret-operator/pages/secretclass.adoc
+++ b/docs/modules/secret-operator/pages/secretclass.adoc
@@ -61,12 +61,10 @@ Users can use podOverrides to extend the certificate lifetime by adding volume a
 
 ==== Certificate Authority rotation
 
-WARNING: CA rotation is an experimental feature, and may be changed or removed at any time.
-
 Certificate authorities also have a limited lifetime, and need to be rotated before they expire to avoid cluster disruption.
 
 If configured to provision its own CA (`autoTls.ca.autoGenerate`), the Secret Operator will create CA certificates that are valid for 2 years (`autoTls.ca.caCertificateLifetime`),
-and can be configured to initiate rotation once less than half of that time remains (by setting `autoTls.ca.experimentalRotateCaCertificate` to `true`).
+and initiate rotation once less than half of that time remains.
 
 To avoid disruption and let the new CA propagate through the cluster, the Secret Operator will prefer using the oldest CA that will last for the entire lifetime of the issued certificate.
 
@@ -85,7 +83,6 @@ spec:
           namespace: default
         autoGenerate: true
         caCertificateLifetime: 700d
-        experimentalRotateCaCertificate: false
       maxCertificateLifetime: 15d # optional
 ----
 
@@ -95,7 +92,6 @@ spec:
                       and `ca.key` respectively.
 `autoTls.ca.autoGenerate`:: Whether the certificate authority should be provisioned and managed by the Secret Operator.
 `autoTls.ca.caCertificateLifetime` :: The lifetime of the certificate authority's root certificate.
-`autoTls.ca.experimentalRotateCaCertificate` :: Whether CA rotation should be enabled.
 `autoTls.maxCertificateLifetime`:: Maximum lifetime the created certificates are allowed to have. In case consumers request a longer lifetime than allowed by this setting, the lifetime will be the minimum of both.
 
 [#backend-kerberoskeytab]

--- a/rust/operator-binary/src/backend/tls/mod.rs
+++ b/rust/operator-binary/src/backend/tls/mod.rs
@@ -146,7 +146,6 @@ impl TlsGenerate {
             secret: ca_secret,
             auto_generate: auto_generate_ca,
             ca_certificate_lifetime,
-            experimental_rotate_ca_certificate,
         }: &crd::AutoTlsCa,
         max_cert_lifetime: Duration,
     ) -> Result<Self> {
@@ -157,8 +156,7 @@ impl TlsGenerate {
                 &ca::Config {
                     manage_ca: *auto_generate_ca,
                     ca_certificate_lifetime: *ca_certificate_lifetime,
-                    rotate_if_ca_expires_before: experimental_rotate_ca_certificate
-                        .then(|| *ca_certificate_lifetime / 2),
+                    rotate_if_ca_expires_before: Some(*ca_certificate_lifetime / 2),
                 },
             )
             .await

--- a/rust/operator-binary/src/crd.rs
+++ b/rust/operator-binary/src/crd.rs
@@ -113,14 +113,6 @@ pub struct AutoTlsCa {
     /// If `autoGenerate: false` then the Secret Operator will log a warning instead.
     #[serde(default = "AutoTlsCa::default_ca_certificate_lifetime")]
     pub ca_certificate_lifetime: Duration,
-
-    /// Whether the CA certificate should be rotated once the old certificate approaches expiration.
-    ///
-    /// This only takes effect when `autoGenerate: true`.
-    ///
-    /// This is an experimental option, that may be removed or changed in the future.
-    #[serde(default)]
-    pub experimental_rotate_ca_certificate: bool,
 }
 
 impl AutoTlsCa {
@@ -314,7 +306,6 @@ mod test {
                         },
                         auto_generate: false,
                         ca_certificate_lifetime: DEFAULT_CA_CERT_LIFETIME,
-                        experimental_rotate_ca_certificate: false,
                     },
                     max_certificate_lifetime: DEFAULT_MAX_CERT_LIFETIME,
                 })
@@ -335,7 +326,6 @@ mod test {
                   namespace: default
                 autoGenerate: true
                 caCertificateLifetime: 100d
-                experimentalRotateCaCertificate: true
               maxCertificateLifetime: 31d
         "#;
         let deserializer = serde_yaml::Deserializer::from_str(input);
@@ -351,8 +341,7 @@ mod test {
                             namespace: "default".to_string(),
                         },
                         auto_generate: true,
-                        ca_certificate_lifetime: Duration::from_days_unchecked(100),
-                        experimental_rotate_ca_certificate: true,
+                        ca_certificate_lifetime: Duration::from_days_unchecked(100)
                     },
                     max_certificate_lifetime: Duration::from_days_unchecked(31),
                 })


### PR DESCRIPTION
Reverts stackabletech/secret-operator#363

This turned out not to be the culprit after all, so let's turn it back on.