### PR TITLE
Default to installing the TLS CA into the operator's target namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- [BREAKING] The TLS CA Secret is now installed into the Namespace of the operator (typically `stackable-operators`), rather than `default`.
+  - Existing users can either migrate (recommended) by copying the CA into the correct Namespace
+    (`kubectl -n default get secret/secret-provisioner-tls-ca -o json | jq '.metadata.namespace = "stackable-operators"' | kubectl create -f-`),
+    or by setting the `secretClasses.tls.caSecretNamespace` Helm flag (`--set secretClasses.tls.caSecretNamespace=default`).
+
 ## [24.3.0] - 2024-03-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- [BREAKING] The TLS CA Secret is now installed into the Namespace of the operator (typically `stackable-operators`), rather than `default`.
+- [BREAKING] The TLS CA Secret is now installed into the Namespace of the operator (typically `stackable-operators`), rather than `default` ([#397]).
   - Existing users can either migrate by either:
       - (Recommended) Copying the CA into the new location
         (`kubectl -n default get secret/secret-provisioner-tls-ca -o json | jq '.metadata.namespace = "stackable-operators"' | kubectl create -f-`)
       - Setting the `secretClasses.tls.caSecretNamespace` Helm flag (`--set secretClasses.tls.caSecretNamespace=default`)
+
+[#397]: https://github.com/stackabletech/secret-operator/pull/397
 
 ## [24.3.0] - 2024-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - [BREAKING] The TLS CA Secret is now installed into the Namespace of the operator (typically `stackable-operators`), rather than `default`.
-  - Existing users can either migrate (recommended) by copying the CA into the correct Namespace
-    (`kubectl -n default get secret/secret-provisioner-tls-ca -o json | jq '.metadata.namespace = "stackable-operators"' | kubectl create -f-`),
-    or by setting the `secretClasses.tls.caSecretNamespace` Helm flag (`--set secretClasses.tls.caSecretNamespace=default`).
+  - Existing users can either migrate by either:
+      - (Recommended) Copying the CA into the new location
+        (`kubectl -n default get secret/secret-provisioner-tls-ca -o json | jq '.metadata.namespace = "stackable-operators"' | kubectl create -f-`)
+      - Setting the `secretClasses.tls.caSecretNamespace` Helm flag (`--set secretClasses.tls.caSecretNamespace=default`)
 
 ## [24.3.0] - 2024-03-20
 

--- a/deploy/helm/secret-operator/templates/secretclasses.yaml
+++ b/deploy/helm/secret-operator/templates/secretclasses.yaml
@@ -11,5 +11,5 @@ spec:
       ca:
         secret:
           name: secret-provisioner-tls-ca
-          namespace: default
+          namespace: {{ .Values.secretClasses.tls.caSecretNamespace | default .Release.Namespace }}
         autoGenerate: true

--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -84,3 +84,9 @@ affinity: {}
 
 # Kubelet dir may vary in environments such as microk8s, see https://github.com/stackabletech/secret-operator/issues/229
 kubeletDir: /var/lib/kubelet
+
+secretClasses:
+  tls:
+    # The namespace that the TLS Certificate Authority is installed into.
+    # Defaults to the namespace where secret-op is installed.
+    caSecretNamespace: null


### PR DESCRIPTION
# Description

See https://github.com/stackabletech/issues/issues/498. OLM manifests are generated from the Helm charts, so fixing it in one should fix it in the other.

Note that this is a breaking change, existing users will need to either `--set secretClasses.tls.caSecretNamespace=default` or copy their CA secret across (`kubectl -n default get secret/secret-provisioner-tls-ca -o json | jq '.metadata.namespace = "stackable-operators"' | kubectl create -f-`).

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
