### PR TITLE
docs: update example to match description on the page

### DIFF
--- a/docs/modules/secret-operator/examples/volume-pod.yaml
+++ b/docs/modules/secret-operator/examples/volume-pod.yaml
@@ -11,7 +11,7 @@ spec:
           metadata:
             annotations:
               secrets.stackable.tech/class: secret # <1>
-              secrets.stackable.tech/scope: node # <2>
+              secrets.stackable.tech/scope: node,pod,service=secret-consumer # <2>
           spec:
             storageClassName: secrets.stackable.tech # <3>
             accessModes: # <4>


### PR DESCRIPTION
The docs say:

> 2. This secret should be scoped by the intersection of node, pod, and the service named secret-consumer

But the example yaml only showed the `node` scope.
