### PR TITLE
Patch for borken arm64 builds

### DIFF
--- a/rust/krb5-sys/build.rs
+++ b/rust/krb5-sys/build.rs
@@ -20,6 +20,16 @@ fn main() {
         .allowlist_var("KRB5_.*")
         .allowlist_var("KADM5_.*")
         .allowlist_var("ENCTYPE_.*")
+        // Variadic functions generate bindings that rustc on ARM64 considers FFI-unsafe.
+        // We don't actually use them, so we can just blocklist the types, and any function
+        // variants that use them.
+        .blocklist_type("va_list")
+        .blocklist_type("__builtin_va_list")
+        .blocklist_type("__va_list_tag")
+        .blocklist_function(".*_vset_.*")
+        .blocklist_function(".*_vwrap_.*")
+        .blocklist_function(".*_vprepend_.*")
+        .blocklist_function(".*_va")
         .new_type_alias("krb5_error_code")
         .new_type_alias("kadm5_ret_t")
         .must_use_type("krb5_error_code")


### PR DESCRIPTION
# Description

`arm64` builds have been broken for `secret-operator` since the va_list type was not FFI safe.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
