### PR TITLE
Update the krb5 image in the integration tests

### DIFF
--- a/tests/templates/kuttl/kerberos-ad/kinit-client.yaml.j2
+++ b/tests/templates/kuttl/kerberos-ad/kinit-client.yaml.j2
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: client
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable23.4.0-rc1
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           command:
             - bash
           args:

--- a/tests/templates/kuttl/kerberos/01-install-kdc.yaml.j2
+++ b/tests/templates/kuttl/kerberos/01-install-kdc.yaml.j2
@@ -22,7 +22,7 @@ spec:
         runAsUser: 0
       initContainers:
         - name: init
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable23.4.0-rc1
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - sh
             - -euo
@@ -43,7 +43,7 @@ spec:
               name: data
       containers:
         - name: kdc
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable23.4.0-rc1
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - krb5kdc
             - -n
@@ -56,7 +56,7 @@ spec:
             - mountPath: /var/kerberos/krb5kdc
               name: data
         - name: kadmind
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable23.4.0-rc1
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - kadmind
             - -nofork
@@ -69,7 +69,7 @@ spec:
             - mountPath: /var/kerberos/krb5kdc
               name: data
         - name: client
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable23.4.0-rc1
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           tty: true
           stdin: true
           env:

--- a/tests/templates/kuttl/kerberos/kinit-client.yaml.j2
+++ b/tests/templates/kuttl/kerberos/kinit-client.yaml.j2
@@ -10,7 +10,7 @@ spec:
       serviceAccount: integration-tests-sa
       containers:
         - name: client
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable23.4.0-rc1
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           command:
             - bash
           args:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -1,15 +1,20 @@
 ---
 dimensions:
+  - name: krb5
+    values:
+      - 1.21.1
   - name: openshift
     values:
       - "false"
 tests:
   - name: kerberos
     dimensions:
+      - krb5
       - openshift
     # Requires manual connection to an AD cluster
     # - name: kerberos-ad
-    #   dimensions: []
+    #   dimensions:
+    #     - krb5
   - name: listener
     dimensions:
       - openshift


### PR DESCRIPTION
# Description

Update the krb5 image in the integration tests

The krb5 version was upgraded from 1.18.2 to 1.21.1 in stackabletech/docker-images#627. As the image with version 1.18.2 is not built anymore, it must be replaced in all integration tests.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
