### PR TITLE
Fix: Always use the 24.7.0 version of the tools image because testing PR artifacts breaks otherwise

### DIFF
--- a/deploy/helm/secret-operator/templates/secret_migration_job.yaml
+++ b/deploy/helm/secret-operator/templates/secret_migration_job.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: migrate-secret
-        image: "{{ .Values.secretMigrationJob.image.repository }}:1.0.0-stackable{{ .Chart.AppVersion }}"
+        image: "{{ .Values.secretMigrationJob.image.repository }}:1.0.0-stackable24.7.0"
         imagePullPolicy: {{ .Values.secretMigrationJob.image.pullPolicy }}
         resources:
             {{ .Values.secretMigrationJob.resources | toYaml | nindent 12 }}


### PR DESCRIPTION
This fixes testing of PR versions of secret-operator since the testruns got broken by https://github.com/stackabletech/secret-operator/pull/476

We stumbed across this:
> When I run a custom test with secret-operator I’m allowed to choose a PR-Version like secret=0.0.0-pr455 which then in the secret-migration Job causes the image being docker.stackable.tech/stackable/tools:1.0.0-stackable0.0.0-pr455 which is a consequence of the image selection mechanism.

Since the `tools` image does not have PR artifacts that relate to the PRs in secret-operator we now specify a fixed version so that testing PRs works again. Currently it fails because the according `tools` image is not present.
We're using 24.7.0 because it's multiarch. It's manually built for now to make this work and will get rebuilt by the release process later.