### PR TITLE
Actually disable credential cache for krb5 provisioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - Active Directory's `samAccountName` generation can now be customized ([#454]).
 
+### Fixed
+
+- Fixed Kerberos keytab provisioning reusing its credential cache ([#490]).
+
 [#454]: https://github.com/stackabletech/secret-operator/pull/454
+[#490]: https://github.com/stackabletech/secret-operator/pull/490
 
 ## [24.7.0] - 2024-07-24
 

--- a/rust/krb5-provision-keytab/src/lib.rs
+++ b/rust/krb5-provision-keytab/src/lib.rs
@@ -75,7 +75,7 @@ pub async fn provision_keytab(krb5_config_path: &Path, req: &Request) -> Result<
         // ldap3 uses the default client keytab to authenticate to the LDAP server
         .env("KRB5_CLIENT_KTNAME", &req.admin_keytab_path)
         // avoid leaking credentials between secret volumes/secretclasses
-        .env("KRB5CCNAME", "MEMORY")
+        .env("KRB5CCNAME", "MEMORY:")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()


### PR DESCRIPTION

# Description

`KRB5CCNAME=MEMORY` will store the cache in a file named `MEMORY`, `KRB5CCNAME=MEMORY:` will store the cache in memory (as intended).

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author

```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
