### PR TITLE
Adds missing KUBERNETES_CLUSTER_DOMAIN environment variable to docs

### DIFF
--- a/docs/modules/secret-operator/pages/reference/environment-variables.adoc
+++ b/docs/modules/secret-operator/pages/reference/environment-variables.adoc
@@ -1,0 +1,66 @@
+= Environment variables
+
+This operator accepts the following environment variables:
+
+== CSI_ENDPOINT
+
+*Required*: true
+
+*Multiple values*: false
+
+The path to the https://github.com/container-storage-interface/spec/blob/master/spec.md[Container Storage Interface] Unix Domain Socket
+that the operator should listen on.
+
+[source]
+----
+export CSI_ENDPOINT=unix:///csi.sock
+cargo run -- run
+----
+
+or via docker:
+
+[source]
+----
+docker run \
+--name secret-operator \
+--network host \
+--env KUBECONFIG=/home/stackable/.kube/config \
+--env CSI_ENDPOINT=unix:///csi.sock controller \
+--mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+docker.stackable.tech/stackable/secret-operator:0.0.0-dev
+----
+
+== KUBERNETES_CLUSTER_DOMAIN
+
+*Default value*: cluster.local
+
+*Required*: false
+
+*Multiple values*: false
+
+This instructs the operator, which value it should use for the Kubernetes `clusterDomain` setting.
+Make sure to keep this in sync with whatever setting your cluster uses.
+Please see the documentation xref:guides:kubernetes-cluster-domain.adoc[on configuring the Kubernetes cluster domain] for more information on this feature.
+
+[source]
+----
+export KUBERNETES_CLUSTER_DOMAIN=mycluster.local
+cargo run -- run --csi-endpoint unix:///csi.sock
+----
+
+or via docker:
+
+[source]
+----
+docker run \
+--name secret-operator \
+--network host \
+--env KUBECONFIG=/home/stackable/.kube/config \
+--env KUBERNETES_CLUSTER_DOMAIN=mycluster.local \
+--mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+docker.stackable.tech/stackable/secret-operator:0.0.0-dev \
+run --csi-endpoint unix:///csi.sock
+----
+
+// TODO: Add NODE_NAME?
+#== NODE_NAME

--- a/docs/modules/secret-operator/pages/reference/environment-variables.adoc
+++ b/docs/modules/secret-operator/pages/reference/environment-variables.adoc
@@ -17,19 +17,6 @@ export CSI_ENDPOINT=unix:///csi.sock
 cargo run -- run
 ----
 
-or via docker:
-
-[source]
-----
-docker run \
---name secret-operator \
---network host \
---env KUBECONFIG=/home/stackable/.kube/config \
---env CSI_ENDPOINT=unix:///csi.sock controller \
---mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
-docker.stackable.tech/stackable/secret-operator:0.0.0-dev
-----
-
 == KUBERNETES_CLUSTER_DOMAIN
 
 *Default value*: cluster.local
@@ -45,22 +32,5 @@ Please see the documentation xref:guides:kubernetes-cluster-domain.adoc[on confi
 [source]
 ----
 export KUBERNETES_CLUSTER_DOMAIN=mycluster.local
-cargo run -- run --csi-endpoint unix:///csi.sock
+cargo run -- run
 ----
-
-or via docker:
-
-[source]
-----
-docker run \
---name secret-operator \
---network host \
---env KUBECONFIG=/home/stackable/.kube/config \
---env KUBERNETES_CLUSTER_DOMAIN=mycluster.local \
---mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
-docker.stackable.tech/stackable/secret-operator:0.0.0-dev \
-run --csi-endpoint unix:///csi.sock
-----
-
-// TODO: Add NODE_NAME?
-#== NODE_NAME

--- a/docs/modules/secret-operator/pages/reference/index.adoc
+++ b/docs/modules/secret-operator/pages/reference/index.adoc
@@ -3,4 +3,5 @@
 Consult the reference documentation section to find exhaustive information on:
 
 * Descriptions and default values of all properties in the CRDs used by this operator in the xref:reference/crds.adoc[].
+* The xref:reference/environment-variables.adoc[] accepted by the operator.
 * The xref:reference/commandline-parameters.adoc[] accepted by the operator.


### PR DESCRIPTION
# Description

Adds missing KUBERNETES_CLUSTER_DOMAIN environment variable to docs.

part of https://github.com/stackabletech/issues/issues/668