### PR TITLE
fix(helm): Add configuration options for the secret migration job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ All notable changes to this project will be documented in this file.
 
 - Made RSA key length configurable for certificates issued by cert-manager ([#528]).
 
+### Fixed
+
+- Helm chart: The secret migration job can be omitted via Helm values ([#536]).
+- Helm chart: The tag of the tools image used for the secret migration job can
+  be changed in the Helm values and defaults to the current SDP version instead
+  of 24.7.0 ([#536]).
+
 [#528]: https://github.com/stackabletech/secret-operator/pull/528
+[#536]: https://github.com/stackabletech/secret-operator/pull/536
 
 ## [24.11.0] - 2024-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ All notable changes to this project will be documented in this file.
 
 - Helm chart: The secret migration job can be omitted via Helm values ([#536]).
 - Helm chart: The tag of the tools image used for the secret migration job can
-  be changed in the Helm values and defaults to the current SDP version instead
-  of 24.7.0 ([#536]).
+  be changed in the Helm values and defaults now to 1.0.0-stackable24.11.0
+  rather than being hard-coded to 1.0.0-stackable24.7.0 ([#536]).
 
 [#528]: https://github.com/stackabletech/secret-operator/pull/528
 [#536]: https://github.com/stackabletech/secret-operator/pull/536

--- a/deploy/helm/secret-operator/templates/secret_migration_job.yaml
+++ b/deploy/helm/secret-operator/templates/secret_migration_job.yaml
@@ -31,7 +31,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: migrate-secret
-        image: "{{ .Values.secretMigrationJob.image.repository }}:{{ .Values.secretMigrationJob.image.tag | default (print "1.0.0-stackable" .Chart.AppVersion) }}"
+        image: "{{ .Values.secretMigrationJob.image.repository }}:{{ .Values.secretMigrationJob.image.tag }}"
         imagePullPolicy: {{ .Values.secretMigrationJob.image.pullPolicy }}
         resources:
             {{ .Values.secretMigrationJob.resources | toYaml | nindent 12 }}

--- a/deploy/helm/secret-operator/templates/secret_migration_job.yaml
+++ b/deploy/helm/secret-operator/templates/secret_migration_job.yaml
@@ -1,4 +1,5 @@
 ---
+{{ if .Values.secretMigrationJob.enabled -}}
 # Migrates the TLS CA key pair from the hard-coded default namespace to the operator namespace
 # See https://github.com/stackabletech/secret-operator/issues/453
 apiVersion: batch/v1
@@ -30,7 +31,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: migrate-secret
-        image: "{{ .Values.secretMigrationJob.image.repository }}:1.0.0-stackable24.7.0"
+        image: "{{ .Values.secretMigrationJob.image.repository }}:{{ .Values.secretMigrationJob.image.tag | default (print "1.0.0-stackable" .Chart.AppVersion) }}"
         imagePullPolicy: {{ .Values.secretMigrationJob.image.pullPolicy }}
         resources:
             {{ .Values.secretMigrationJob.resources | toYaml | nindent 12 }}
@@ -53,3 +54,4 @@ spec:
             fi
           fi
       restartPolicy: Never
+{{- end }}

--- a/deploy/helm/secret-operator/templates/secret_migration_rbac.yaml
+++ b/deploy/helm/secret-operator/templates/secret_migration_rbac.yaml
@@ -1,4 +1,5 @@
 ---
+{{ if .Values.secretMigrationJob.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -54,3 +55,4 @@ rules:
       - create
       - patch
       - update
+{{- end }}

--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -9,7 +9,7 @@ secretMigrationJob:
   enabled: true
   image:
     repository: docker.stackable.tech/stackable/tools
-    tag: null  # defaults to 1.0.0-stackable{{appVersion}}
+    tag: 1.0.0-stackable24.11.0
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -6,8 +6,10 @@ image:
   pullSecrets: []
 
 secretMigrationJob:
+  enabled: true
   image:
     repository: docker.stackable.tech/stackable/tools
+    tag: null  # defaults to 1.0.0-stackable{{appVersion}}
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
# Description

* Helm chart: The secret migration job can be omitted via Helm values.
* Helm chart: The tag of the tools image used for the secret migration job can be changed in the Helm values and defaults to the current SDP version instead of 24.7.0.

part of #477 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
