### PR TITLE
Provision Kerberos principals for IP addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Made RSA key length configurable for certificates issued by cert-manager ([#528]).
+- Kerberos principal backends now also provision principals for IP address, not just DNS hostnames ([#552]).
 
 ### Changed
 
@@ -28,6 +29,7 @@ All notable changes to this project will be documented in this file.
 [#536]: https://github.com/stackabletech/secret-operator/pull/536
 [#543]: https://github.com/stackabletech/secret-operator/pull/543
 [#548]: https://github.com/stackabletech/secret-operator/pull/548
+[#552]: https://github.com/stackabletech/secret-operator/pull/552
 
 ## [24.11.0] - 2024-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,6 @@ All notable changes to this project will be documented in this file.
 - Made RSA key length configurable for certificates issued by cert-manager ([#528]).
 - Kerberos principal backends now also provision principals for IP address, not just DNS hostnames ([#552]).
 
-### Changed
-
-- Append a dot (`.`) to the default cluster domain to reduce DNS requests ([#543]).
-
 ### Fixed
 
 - Helm chart: The secret migration job can be omitted via Helm values ([#536]).
@@ -27,7 +23,6 @@ All notable changes to this project will be documented in this file.
 
 [#528]: https://github.com/stackabletech/secret-operator/pull/528
 [#536]: https://github.com/stackabletech/secret-operator/pull/536
-[#543]: https://github.com/stackabletech/secret-operator/pull/543
 [#548]: https://github.com/stackabletech/secret-operator/pull/548
 [#552]: https://github.com/stackabletech/secret-operator/pull/552
 

--- a/rust/operator-binary/src/backend/kerberos_keytab.rs
+++ b/rust/operator-binary/src/backend/kerberos_keytab.rs
@@ -208,13 +208,18 @@ cluster.local = {realm_name}
                             scope: scope.clone(),
                         })?
                 {
-                    if let Address::Dns(hostname) = addr {
-                        pod_principals.push(
-                            format!("{service_name}/{hostname}")
-                                .try_into()
-                                .context(PodPrincipalSnafu)?,
-                        );
-                    }
+                    pod_principals.push(
+                        match addr {
+                            Address::Dns(hostname) => {
+                                format!("{service_name}/{hostname}")
+                            }
+                            Address::Ip(ip) => {
+                                format!("{service_name}/{ip}")
+                            }
+                        }
+                        .try_into()
+                        .context(PodPrincipalSnafu)?,
+                    );
                 }
             }
         }

--- a/tests/templates/kuttl/kerberos/01-install-kdc.yaml.j2
+++ b/tests/templates/kuttl/kerberos/01-install-kdc.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: envsubst '$NAMESPACE' < secretclass.yaml | kubectl apply -f -
+  - script: envsubst '$NAMESPACE' < listenerclass.yaml | kubectl apply -f -
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/kerberos/kinit-client.yaml.j2
+++ b/tests/templates/kuttl/kerberos/kinit-client.yaml.j2
@@ -21,6 +21,10 @@ spec:
               klist -k /stackable/krb/keytab -teKC
               echo kiniting node
               kinit -kt /stackable/krb/keytab -p HTTP/$NODE_NAME
+              echo kiniting node ip
+              NODE_IP="$(cat /stackable/listener/nodeport-ip/default-address/address)"
+              echo node ip is "$NODE_IP"
+              kinit -kt /stackable/krb/keytab -p "HTTP/$NODE_IP"
               echo kiniting service
               kinit -kt /stackable/krb/keytab -p HTTP/krb5-client.$NAMESPACE.svc.cluster.local
               echo kiniting pod
@@ -39,6 +43,11 @@ spec:
           volumeMounts:
             - mountPath: /stackable/krb
               name: kerberos
+            - mountPath: /stackable/listener/nodeport-ip
+              name: listener-nodeport-ip
+          ports:
+            - name: dummy
+              containerPort: 9999
       volumes:
         - name: kerberos
           ephemeral:
@@ -46,9 +55,22 @@ spec:
               metadata:
                 annotations:
                   secrets.stackable.tech/class: kerberos-$NAMESPACE
-                  secrets.stackable.tech/scope: node,pod
+                  secrets.stackable.tech/scope: node,pod,listener-volume=listener-nodeport-ip
               spec:
                 storageClassName: secrets.stackable.tech
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: "1"
+        - name: listener-nodeport-ip
+          ephemeral:
+            volumeClaimTemplate:
+              metadata:
+                annotations:
+                  listeners.stackable.tech/listener-class: nodeport-ip-$NAMESPACE
+              spec:
+                storageClassName: listeners.stackable.tech
                 accessModes:
                   - ReadWriteOnce
                 resources:

--- a/tests/templates/kuttl/kerberos/listenerclass.yaml
+++ b/tests/templates/kuttl/kerberos/listenerclass.yaml
@@ -1,0 +1,9 @@
+# $NAMESPACE will be replaced with the namespace of the test case.
+---
+apiVersion: listeners.stackable.tech/v1alpha1
+kind: ListenerClass
+metadata:
+  name: nodeport-ip-$NAMESPACE
+spec:
+  serviceType: NodePort
+  preferredAddressType: IP


### PR DESCRIPTION
# Description

Previously, Kerberos principals were only provisioned for hostnames. This PR also adds support for IP addresses, since we default to using IP addresses for NodePort listeners (vs the old `node` scope, which used hostnames).

Fixes https://github.com/stackabletech/kafka-operator/issues/812.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```