### PR TITLE
docs: Fix the k8sSearch example

### DIFF
--- a/docs/modules/secret-operator/pages/secretclass.adoc
+++ b/docs/modules/secret-operator/pages/secretclass.adoc
@@ -362,16 +362,12 @@ Please note that the contents in the volume will not update when the Secret cont
 
 [source,yaml]
 ----
-apiVersion: apps/v1
+---
+apiVersion: v1
 kind: Pod
 metadata:
   name: my-app
-  labels:
-    app.kubernetes.io/name: my-app
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: my-app
   containers:
     #... skipped for brevity
     volumeMounts:
@@ -409,6 +405,7 @@ metadata:
   name: my-admin-credentials
   labels:
     secrets.stackable.tech/class: admin-credentials-class
+    secrets.stackable.tech/pod: my-app
 stringData:
   user: admin
   password: secret
@@ -416,8 +413,7 @@ stringData:
 
 
 xref:scope.adoc[Scopes] are translated into additional label filters of the form `secrets.stackable.tech/$SCOPE: $SCOPE_VALUE`.
-For example, a `Pod` named `foo` mounting a `k8sSearch` secret with the xref:scope.adoc#pod[`pod`] scope would add the label filter
-`secrets.stackable.tech/pod: foo`.
+For example, a Pod named `foo` mounting a `k8sSearch` Secret with the xref:scope.adoc#pod[`pod`] scope would add the label filter `secrets.stackable.tech/pod: foo`.
 
 ==== Reference
 


### PR DESCRIPTION
# Description

Fix the k8sSearch example.

The Pod specification was invalid and the label `secrets.stackable.tech/pod` on the Secret was missing.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
