### PR TITLE
feat: Add format-specific annotations to override secret file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add format-specific annotations to override secret file names ([#572]). The following new
+  annotations are available:
+  - `secrets.stackable.tech/format.tls-pkcs12.keystore-name`
+  - `secrets.stackable.tech/format.tls-pkcs12.truststore-name`
+  - `secrets.stackable.tech/format.tls-pem.cert-name`
+  - `secrets.stackable.tech/format.tls-pem.key-name`
+  - `secrets.stackable.tech/format.tls-pem.ca-name`
+
+[#572]: https://github.com/stackabletech/secret-operator/pull/572
+
 ## [25.3.0] - 2025-03-21
 
 ### Removed

--- a/docs/modules/secret-operator/pages/volume.adoc
+++ b/docs/modules/secret-operator/pages/volume.adoc
@@ -50,6 +50,61 @@ The xref:secretclass.adoc#format[format] that the secret should be written as.
 
 This can be either the default output format of the xref:secretclass.adoc#backend[backend], or a format that it defines a conversion into.
 
+=== `secrets.stackable.tech/format.tls-pkcs12.keystore-name`
+
+*Required*: false
+
+*Default value*: `keystore.p12`
+
+*Backends*: xref:secretclass.adoc#backend-autotls[]
+
+An alternative name for the keystore file.
+Has no effect if the `format` is not `tls-pkcs12`.
+
+=== `secrets.stackable.tech/format.tls-pkcs12.truststore-name`
+
+*Required*: false
+
+*Default value*: `truststore.p12`
+
+*Backends*: xref:secretclass.adoc#backend-autotls[]
+
+An alternative name for the truststore file.
+Has no effect if the `format` is not `tls-pkcs12`.
+
+=== `secrets.stackable.tech/format.tls-pem.cert-name`
+
+*Required*: false
+
+*Default value*: `tls.crt`
+
+*Backends*: xref:secretclass.adoc#backend-autotls[]
+
+An alternative name for TLS PEM certificate.
+Has no effect if the `format` is not `tls-pem`.
+
+=== `secrets.stackable.tech/format.tls-pem.key-name`
+
+*Required*: false
+
+*Default value*: `tls.key`
+
+*Backends*: xref:secretclass.adoc#backend-autotls[]
+
+An alternative name for TLS PEM certificate key.
+Has no effect if the `format` is not `tls-pem`.
+
+=== `secrets.stackable.tech/format.tls-pem.ca-name`
+
+*Required*: false
+
+*Default value*: `ca.crt`
+
+*Backends*: xref:secretclass.adoc#backend-autotls[]
+
+An alternative name for TLS PEM certificate authority.
+Has no effect if the `format` is not `tls-pem`.
+
 === `secrets.stackable.tech/backend.autotls.cert.lifetime`
 
 *Required*: false

--- a/rust/operator-binary/src/backend/mod.rs
+++ b/rust/operator-binary/src/backend/mod.rs
@@ -25,7 +25,13 @@ use stackable_operator::{
 pub use tls::TlsGenerate;
 
 use self::pod_info::SchedulingPodInfo;
-use crate::format::{SecretData, SecretFormat};
+use crate::format::{
+    well_known::{
+        FILE_PEM_CERT_CA, FILE_PEM_CERT_CERT, FILE_PEM_CERT_KEY, FILE_PKCS12_CERT_KEYSTORE,
+        FILE_PKCS12_CERT_TRUSTSTORE,
+    },
+    SecretData, SecretFormat,
+};
 
 /// Configuration provided by the `Volume` selecting what secret data should be provided
 ///
@@ -96,6 +102,51 @@ pub struct SecretVolumeSelector {
     )]
     pub compat_tls_pkcs12_password: Option<String>,
 
+    /// An alternative name used for the TLS PKCS#12 keystore file.
+    ///
+    /// Has no effect if the `format` is not `tls-pkcs12`.
+    #[serde(
+        rename = "secrets.stackable.tech/format.tls-pkcs12.keystore-name",
+        default = "default_pkcs12_keystore_name"
+    )]
+    pub tls_pkcs12_keystore_name: String,
+
+    /// An alternative name used for the TLS PKCS#12 keystore file.
+    ///
+    /// Has no effect if the `format` is not `tls-pkcs12`.
+    #[serde(
+        rename = "secrets.stackable.tech/format.tls-pkcs12.truststore-name",
+        default = "default_pkcs12_truststore_name"
+    )]
+    pub tls_pkcs12_truststore_name: String,
+
+    /// An alternative name used for the TLS PEM certificate.
+    ///
+    /// Has no effect if the `format` is not `tls-pem`.
+    #[serde(
+        rename = "secrets.stackable.tech/format.tls-pem.cert-name",
+        default = "default_tls_pem_cert_name"
+    )]
+    pub tls_pem_cert_name: String,
+
+    /// An alternative name used for the TLS PEM certificate key.
+    ///
+    /// Has no effect if the `format` is not `tls-pem`.
+    #[serde(
+        rename = "secrets.stackable.tech/format.tls-pem.key-name",
+        default = "default_tls_pem_key_name"
+    )]
+    pub tls_pem_key_name: String,
+
+    /// An alternative name used for the TLS PEM certificate authority.
+    ///
+    /// Has no effect if the `format` is not `tls-pem`.
+    #[serde(
+        rename = "secrets.stackable.tech/format.tls-pem.ca-name",
+        default = "default_tls_pem_ca_name"
+    )]
+    pub tls_pem_ca_name: String,
+
     /// The TLS cert lifetime (when using the [`tls`] backend).
     /// The format is documented in <https://docs.stackable.tech/home/nightly/concepts/duration>.
     #[serde(
@@ -162,6 +213,26 @@ fn default_cert_lifetime() -> Duration {
 
 fn default_cert_jitter_factor() -> f64 {
     tls::DEFAULT_CERT_JITTER_FACTOR
+}
+
+fn default_pkcs12_keystore_name() -> String {
+    FILE_PKCS12_CERT_KEYSTORE.to_owned()
+}
+
+fn default_pkcs12_truststore_name() -> String {
+    FILE_PKCS12_CERT_TRUSTSTORE.to_owned()
+}
+
+fn default_tls_pem_cert_name() -> String {
+    FILE_PEM_CERT_CERT.to_owned()
+}
+
+fn default_tls_pem_key_name() -> String {
+    FILE_PEM_CERT_KEY.to_owned()
+}
+
+fn default_tls_pem_ca_name() -> String {
+    FILE_PEM_CERT_CA.to_owned()
 }
 
 #[derive(Snafu, Debug)]

--- a/rust/operator-binary/src/backend/mod.rs
+++ b/rust/operator-binary/src/backend/mod.rs
@@ -297,3 +297,55 @@ impl SecretBackendError for Infallible {
         match *self {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde::de::{value::MapDeserializer, IntoDeserializer};
+
+    use super::*;
+
+    fn required_fields_map() -> HashMap<String, String> {
+        HashMap::from([
+            (
+                "secrets.stackable.tech/class".to_owned(),
+                "my-class".to_owned(),
+            ),
+            (
+                "csi.storage.k8s.io/pod.name".to_owned(),
+                "my-pod".to_owned(),
+            ),
+            (
+                "csi.storage.k8s.io/pod.namespace".to_owned(),
+                "my-namespace".to_owned(),
+            ),
+        ])
+    }
+
+    #[test]
+    fn deserialize_selector() {
+        let map = required_fields_map();
+
+        let _ =
+            SecretVolumeSelector::deserialize::<MapDeserializer<'_, _, serde::de::value::Error>>(
+                map.into_deserializer(),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn deserialize_selector_compat() {
+        let mut map = required_fields_map();
+        map.insert(
+            "secrets.stackable.tech/format.compatibility.tls-pkcs12.password".to_owned(),
+            "supersecret".to_owned(),
+        );
+
+        let _ =
+            SecretVolumeSelector::deserialize::<MapDeserializer<'_, _, serde::de::value::Error>>(
+                map.into_deserializer(),
+            )
+            .unwrap();
+    }
+}

--- a/rust/operator-binary/src/backend/mod.rs
+++ b/rust/operator-binary/src/backend/mod.rs
@@ -25,7 +25,10 @@ use stackable_operator::{
 pub use tls::TlsGenerate;
 
 use self::pod_info::SchedulingPodInfo;
-use crate::format::{well_known::NamingOptions, SecretData, SecretFormat};
+use crate::format::{
+    well_known::{CompatibilityOptions, NamingOptions},
+    SecretData, SecretFormat,
+};
 
 /// Configuration provided by the `Volume` selecting what secret data should be provided
 ///
@@ -85,16 +88,9 @@ pub struct SecretVolumeSelector {
     )]
     pub kerberos_service_names: Vec<String>,
 
-    /// The password used to encrypt the TLS PKCS#12 keystore
-    ///
-    /// Required for some applications that misbehave with blank keystore passwords (such as Hadoop).
-    /// Has no effect if `format` is not `tls-pkcs12`.
-    #[serde(
-        rename = "secrets.stackable.tech/format.compatibility.tls-pkcs12.password",
-        deserialize_with = "SecretVolumeSelector::deserialize_some",
-        default
-    )]
-    pub compat_tls_pkcs12_password: Option<String>,
+    /// Compatibility options used by (legacy) applications.
+    #[serde(flatten)]
+    pub compat: CompatibilityOptions,
 
     /// The (custom) filenames used by secrets.
     #[serde(flatten)]

--- a/rust/operator-binary/src/backend/mod.rs
+++ b/rust/operator-binary/src/backend/mod.rs
@@ -25,13 +25,7 @@ use stackable_operator::{
 pub use tls::TlsGenerate;
 
 use self::pod_info::SchedulingPodInfo;
-use crate::format::{
-    well_known::{
-        FILE_PEM_CERT_CA, FILE_PEM_CERT_CERT, FILE_PEM_CERT_KEY, FILE_PKCS12_CERT_KEYSTORE,
-        FILE_PKCS12_CERT_TRUSTSTORE,
-    },
-    SecretData, SecretFormat,
-};
+use crate::format::{well_known::NamingOptions, SecretData, SecretFormat};
 
 /// Configuration provided by the `Volume` selecting what secret data should be provided
 ///
@@ -102,50 +96,9 @@ pub struct SecretVolumeSelector {
     )]
     pub compat_tls_pkcs12_password: Option<String>,
 
-    /// An alternative name used for the TLS PKCS#12 keystore file.
-    ///
-    /// Has no effect if the `format` is not `tls-pkcs12`.
-    #[serde(
-        rename = "secrets.stackable.tech/format.tls-pkcs12.keystore-name",
-        default = "default_pkcs12_keystore_name"
-    )]
-    pub tls_pkcs12_keystore_name: String,
-
-    /// An alternative name used for the TLS PKCS#12 keystore file.
-    ///
-    /// Has no effect if the `format` is not `tls-pkcs12`.
-    #[serde(
-        rename = "secrets.stackable.tech/format.tls-pkcs12.truststore-name",
-        default = "default_pkcs12_truststore_name"
-    )]
-    pub tls_pkcs12_truststore_name: String,
-
-    /// An alternative name used for the TLS PEM certificate.
-    ///
-    /// Has no effect if the `format` is not `tls-pem`.
-    #[serde(
-        rename = "secrets.stackable.tech/format.tls-pem.cert-name",
-        default = "default_tls_pem_cert_name"
-    )]
-    pub tls_pem_cert_name: String,
-
-    /// An alternative name used for the TLS PEM certificate key.
-    ///
-    /// Has no effect if the `format` is not `tls-pem`.
-    #[serde(
-        rename = "secrets.stackable.tech/format.tls-pem.key-name",
-        default = "default_tls_pem_key_name"
-    )]
-    pub tls_pem_key_name: String,
-
-    /// An alternative name used for the TLS PEM certificate authority.
-    ///
-    /// Has no effect if the `format` is not `tls-pem`.
-    #[serde(
-        rename = "secrets.stackable.tech/format.tls-pem.ca-name",
-        default = "default_tls_pem_ca_name"
-    )]
-    pub tls_pem_ca_name: String,
+    /// The (custom) filenames used by secrets.
+    #[serde(flatten)]
+    pub names: NamingOptions,
 
     /// The TLS cert lifetime (when using the [`tls`] backend).
     /// The format is documented in <https://docs.stackable.tech/home/nightly/concepts/duration>.
@@ -213,26 +166,6 @@ fn default_cert_lifetime() -> Duration {
 
 fn default_cert_jitter_factor() -> f64 {
     tls::DEFAULT_CERT_JITTER_FACTOR
-}
-
-fn default_pkcs12_keystore_name() -> String {
-    FILE_PKCS12_CERT_KEYSTORE.to_owned()
-}
-
-fn default_pkcs12_truststore_name() -> String {
-    FILE_PKCS12_CERT_TRUSTSTORE.to_owned()
-}
-
-fn default_tls_pem_cert_name() -> String {
-    FILE_PEM_CERT_CERT.to_owned()
-}
-
-fn default_tls_pem_key_name() -> String {
-    FILE_PEM_CERT_KEY.to_owned()
-}
-
-fn default_tls_pem_ca_name() -> String {
-    FILE_PEM_CERT_CA.to_owned()
 }
 
 #[derive(Snafu, Debug)]

--- a/rust/operator-binary/src/csi_server/node.rs
+++ b/rust/operator-binary/src/csi_server/node.rs
@@ -229,7 +229,7 @@ impl SecretProvisionerNode {
         target_path: &Path,
         data: SecretContents,
         format: Option<SecretFormat>,
-        names: &NamingOptions,
+        names: NamingOptions,
         compat: &CompatibilityOptions,
     ) -> Result<(), PublishError> {
         let create_secret = {
@@ -421,13 +421,7 @@ impl Node for SecretProvisionerNode {
                     &target_path,
                     data,
                     selector.format,
-                    &NamingOptions {
-                        tls_pkcs12_keystore_name: selector.tls_pkcs12_keystore_name,
-                        tls_pkcs12_truststore_name: selector.tls_pkcs12_truststore_name,
-                        tls_pem_cert_name: selector.tls_pem_cert_name,
-                        tls_pem_key_name: selector.tls_pem_key_name,
-                        tls_pem_ca_name: selector.tls_pem_ca_name,
-                    },
+                    selector.names,
                     &CompatibilityOptions {
                         tls_pkcs12_password: selector.compat_tls_pkcs12_password,
                     },

--- a/rust/operator-binary/src/csi_server/node.rs
+++ b/rust/operator-binary/src/csi_server/node.rs
@@ -230,7 +230,7 @@ impl SecretProvisionerNode {
         data: SecretContents,
         format: Option<SecretFormat>,
         names: NamingOptions,
-        compat: &CompatibilityOptions,
+        compat: CompatibilityOptions,
     ) -> Result<(), PublishError> {
         let create_secret = {
             let mut opts = OpenOptions::new();
@@ -420,11 +420,10 @@ impl Node for SecretProvisionerNode {
                 self.save_secret_data(
                     &target_path,
                     data,
+                    // NOTE (@Techassi): At this point, we might want to pass the whole selector instead
                     selector.format,
                     selector.names,
-                    &CompatibilityOptions {
-                        tls_pkcs12_password: selector.compat_tls_pkcs12_password,
-                    },
+                    selector.compat,
                 )
                 .await?;
                 Ok(Response::new(NodePublishVolumeResponse {}))

--- a/rust/operator-binary/src/csi_server/node.rs
+++ b/rust/operator-binary/src/csi_server/node.rs
@@ -65,13 +65,13 @@ enum PublishError {
     #[snafu(display("backend failed to get secret data"))]
     BackendGetSecretData { source: backend::dynamic::DynError },
 
-    #[snafu(display("failed to create secret parent dir {}", path.display()))]
+    #[snafu(display("failed to create secret parent dir {path:?}"))]
     CreateDir {
         source: std::io::Error,
         path: PathBuf,
     },
 
-    #[snafu(display("failed to mount volume mount directory {}", path.display()))]
+    #[snafu(display("failed to mount volume mount directory {path:?}"))]
     Mount {
         source: std::io::Error,
         path: PathBuf,
@@ -80,28 +80,28 @@ enum PublishError {
     #[snafu(display("failed to convert secret data into desired format"))]
     FormatData { source: format::IntoFilesError },
 
-    #[snafu(display("failed to set volume permissions for {}", path.display()))]
+    #[snafu(display("failed to set volume permissions for {path:?}"))]
     SetDirPermissions {
         source: std::io::Error,
         path: PathBuf,
     },
 
-    #[snafu(display("failed to create secret file {}", path.display()))]
+    #[snafu(display("failed to create secret file {path:?}"))]
     CreateFile {
         source: std::io::Error,
         path: PathBuf,
     },
 
-    #[snafu(display("failed to write secret file {}", path.display()))]
+    #[snafu(display("failed to write secret file {path:?}"))]
     WriteFile {
         source: std::io::Error,
         path: PathBuf,
     },
 
-    #[snafu(display("file path {} must not contain more than one component", path.display()))]
+    #[snafu(display("file path {path:?} must not contain more than one component"))]
     InvalidComponentCount { path: PathBuf },
 
-    #[snafu(display("file path {} must not be absolute", path.display()))]
+    #[snafu(display("file path {path:?} must not be absolute"))]
     InvalidAbsolutePath { path: PathBuf },
 
     #[snafu(display("failed to tag pod with expiry metadata"))]

--- a/rust/operator-binary/src/format/convert.rs
+++ b/rust/operator-binary/src/format/convert.rs
@@ -16,7 +16,7 @@ use crate::format::utils::split_pem_certificates;
 pub fn convert(
     from: WellKnownSecretData,
     to: SecretFormat,
-    compat: &CompatibilityOptions,
+    compat: CompatibilityOptions,
 ) -> Result<WellKnownSecretData, ConvertError> {
     match (from, to) {
         // Converting into the current format is always a no-op

--- a/rust/operator-binary/src/format/mod.rs
+++ b/rust/operator-binary/src/format/mod.rs
@@ -7,6 +7,7 @@ pub use self::{
     convert::ConvertError,
     well_known::{FromFilesError as ParseError, SecretFormat, WellKnownSecretData},
 };
+use crate::format::well_known::NamingOptions;
 
 mod convert;
 mod utils;
@@ -30,13 +31,14 @@ impl SecretData {
     pub fn into_files(
         self,
         format: Option<SecretFormat>,
+        names: &NamingOptions,
         compat: &CompatibilityOptions,
     ) -> Result<SecretFiles, IntoFilesError> {
         if let Some(format) = format {
-            Ok(self.parse()?.convert_to(format, compat)?.into_files())
+            Ok(self.parse()?.convert_to(format, compat)?.into_files(names))
         } else {
             Ok(match self {
-                SecretData::WellKnown(data) => data.into_files(),
+                SecretData::WellKnown(data) => data.into_files(names),
                 SecretData::Unknown(files) => files,
             })
         }

--- a/rust/operator-binary/src/format/mod.rs
+++ b/rust/operator-binary/src/format/mod.rs
@@ -31,7 +31,7 @@ impl SecretData {
     pub fn into_files(
         self,
         format: Option<SecretFormat>,
-        names: &NamingOptions,
+        names: NamingOptions,
         compat: &CompatibilityOptions,
     ) -> Result<SecretFiles, IntoFilesError> {
         if let Some(format) = format {

--- a/rust/operator-binary/src/format/mod.rs
+++ b/rust/operator-binary/src/format/mod.rs
@@ -32,7 +32,7 @@ impl SecretData {
         self,
         format: Option<SecretFormat>,
         names: NamingOptions,
-        compat: &CompatibilityOptions,
+        compat: CompatibilityOptions,
     ) -> Result<SecretFiles, IntoFilesError> {
         if let Some(format) = format {
             Ok(self.parse()?.convert_to(format, compat)?.into_files(names))

--- a/rust/operator-binary/src/format/well_known.rs
+++ b/rust/operator-binary/src/format/well_known.rs
@@ -4,12 +4,12 @@ use strum::EnumDiscriminants;
 
 use super::{convert, ConvertError, SecretFiles};
 
-pub const FILE_PEM_CERT_CERT: &str = "tls.crt";
-pub const FILE_PEM_CERT_KEY: &str = "tls.key";
-pub const FILE_PEM_CERT_CA: &str = "ca.crt";
+const FILE_PEM_CERT_CERT: &str = "tls.crt";
+const FILE_PEM_CERT_KEY: &str = "tls.key";
+const FILE_PEM_CERT_CA: &str = "ca.crt";
 
-pub const FILE_PKCS12_CERT_KEYSTORE: &str = "keystore.p12";
-pub const FILE_PKCS12_CERT_TRUSTSTORE: &str = "truststore.p12";
+const FILE_PKCS12_CERT_KEYSTORE: &str = "keystore.p12";
+const FILE_PKCS12_CERT_TRUSTSTORE: &str = "truststore.p12";
 
 const FILE_KERBEROS_KEYTAB_KEYTAB: &str = "keytab";
 const FILE_KERBEROS_KEYTAB_KRB5_CONF: &str = "krb5.conf";
@@ -46,24 +46,24 @@ pub enum WellKnownSecretData {
 }
 
 impl WellKnownSecretData {
-    pub fn into_files(self, names: &NamingOptions) -> SecretFiles {
+    pub fn into_files(self, names: NamingOptions) -> SecretFiles {
         match self {
             WellKnownSecretData::TlsPem(TlsPem {
                 certificate_pem,
                 key_pem,
                 ca_pem,
             }) => [
-                (names.tls_pem_cert_name.to_string(), certificate_pem),
-                (names.tls_pem_key_name.to_string(), key_pem),
-                (names.tls_pem_ca_name.to_string(), ca_pem),
+                (names.tls_pem_cert_name, certificate_pem),
+                (names.tls_pem_key_name, key_pem),
+                (names.tls_pem_ca_name, ca_pem),
             ]
             .into(),
             WellKnownSecretData::TlsPkcs12(TlsPkcs12 {
                 keystore,
                 truststore,
             }) => [
-                (names.tls_pkcs12_keystore_name.to_string(), keystore),
-                (names.tls_pkcs12_truststore_name.to_string(), truststore),
+                (names.tls_pkcs12_keystore_name, keystore),
+                (names.tls_pkcs12_truststore_name, truststore),
             ]
             .into(),
             WellKnownSecretData::Kerberos(Kerberos { keytab, krb5_conf }) => [
@@ -127,12 +127,72 @@ pub struct CompatibilityOptions {
 ///
 /// The fields will either contain the default value or the custom user-provided one. This is also
 /// the reason why the fields are not wrapped in [`Option`].
+#[derive(Debug, Deserialize)]
 pub struct NamingOptions {
+    /// An alternative name used for the TLS PKCS#12 keystore file.
+    ///
+    /// Has no effect if the `format` is not `tls-pkcs12`.
+    #[serde(
+        rename = "secrets.stackable.tech/format.tls-pkcs12.keystore-name",
+        default = "default_pkcs12_keystore_name"
+    )]
     pub tls_pkcs12_keystore_name: String,
+
+    /// An alternative name used for the TLS PKCS#12 keystore file.
+    ///
+    /// Has no effect if the `format` is not `tls-pkcs12`.
+    #[serde(
+        rename = "secrets.stackable.tech/format.tls-pkcs12.truststore-name",
+        default = "default_pkcs12_truststore_name"
+    )]
     pub tls_pkcs12_truststore_name: String,
+
+    /// An alternative name used for the TLS PEM certificate.
+    ///
+    /// Has no effect if the `format` is not `tls-pem`.
+    #[serde(
+        rename = "secrets.stackable.tech/format.tls-pem.cert-name",
+        default = "default_tls_pem_cert_name"
+    )]
     pub tls_pem_cert_name: String,
+
+    /// An alternative name used for the TLS PEM certificate key.
+    ///
+    /// Has no effect if the `format` is not `tls-pem`.
+    #[serde(
+        rename = "secrets.stackable.tech/format.tls-pem.key-name",
+        default = "default_tls_pem_key_name"
+    )]
     pub tls_pem_key_name: String,
+
+    /// An alternative name used for the TLS PEM certificate authority.
+    ///
+    /// Has no effect if the `format` is not `tls-pem`.
+    #[serde(
+        rename = "secrets.stackable.tech/format.tls-pem.ca-name",
+        default = "default_tls_pem_ca_name"
+    )]
     pub tls_pem_ca_name: String,
+}
+
+fn default_pkcs12_keystore_name() -> String {
+    FILE_PKCS12_CERT_KEYSTORE.to_owned()
+}
+
+fn default_pkcs12_truststore_name() -> String {
+    FILE_PKCS12_CERT_TRUSTSTORE.to_owned()
+}
+
+fn default_tls_pem_cert_name() -> String {
+    FILE_PEM_CERT_CERT.to_owned()
+}
+
+fn default_tls_pem_key_name() -> String {
+    FILE_PEM_CERT_KEY.to_owned()
+}
+
+fn default_tls_pem_ca_name() -> String {
+    FILE_PEM_CERT_CA.to_owned()
 }
 
 #[derive(Snafu, Debug)]

--- a/rust/operator-binary/src/format/well_known.rs
+++ b/rust/operator-binary/src/format/well_known.rs
@@ -4,12 +4,12 @@ use strum::EnumDiscriminants;
 
 use super::{convert, ConvertError, SecretFiles};
 
-const FILE_PEM_CERT_CERT: &str = "tls.crt";
-const FILE_PEM_CERT_KEY: &str = "tls.key";
-const FILE_PEM_CERT_CA: &str = "ca.crt";
+pub const FILE_PEM_CERT_CERT: &str = "tls.crt";
+pub const FILE_PEM_CERT_KEY: &str = "tls.key";
+pub const FILE_PEM_CERT_CA: &str = "ca.crt";
 
-const FILE_PKCS12_CERT_KEYSTORE: &str = "keystore.p12";
-const FILE_PKCS12_CERT_TRUSTSTORE: &str = "truststore.p12";
+pub const FILE_PKCS12_CERT_KEYSTORE: &str = "keystore.p12";
+pub const FILE_PKCS12_CERT_TRUSTSTORE: &str = "truststore.p12";
 
 const FILE_KERBEROS_KEYTAB_KEYTAB: &str = "keytab";
 const FILE_KERBEROS_KEYTAB_KRB5_CONF: &str = "krb5.conf";
@@ -46,24 +46,24 @@ pub enum WellKnownSecretData {
 }
 
 impl WellKnownSecretData {
-    pub fn into_files(self) -> SecretFiles {
+    pub fn into_files(self, names: &NamingOptions) -> SecretFiles {
         match self {
             WellKnownSecretData::TlsPem(TlsPem {
                 certificate_pem,
                 key_pem,
                 ca_pem,
             }) => [
-                (FILE_PEM_CERT_CERT.to_string(), certificate_pem),
-                (FILE_PEM_CERT_KEY.to_string(), key_pem),
-                (FILE_PEM_CERT_CA.to_string(), ca_pem),
+                (names.tls_pem_cert_name.to_string(), certificate_pem),
+                (names.tls_pem_key_name.to_string(), key_pem),
+                (names.tls_pem_ca_name.to_string(), ca_pem),
             ]
             .into(),
             WellKnownSecretData::TlsPkcs12(TlsPkcs12 {
                 keystore,
                 truststore,
             }) => [
-                (FILE_PKCS12_CERT_KEYSTORE.to_string(), keystore),
-                (FILE_PKCS12_CERT_TRUSTSTORE.to_string(), truststore),
+                (names.tls_pkcs12_keystore_name.to_string(), keystore),
+                (names.tls_pkcs12_truststore_name.to_string(), truststore),
             ]
             .into(),
             WellKnownSecretData::Kerberos(Kerberos { keytab, krb5_conf }) => [
@@ -121,6 +121,18 @@ impl WellKnownSecretData {
 #[derive(Default)]
 pub struct CompatibilityOptions {
     pub tls_pkcs12_password: Option<String>,
+}
+
+/// Options to customize the well-known format file names.
+///
+/// The fields will either contain the default value or the custom user-provided one. This is also
+/// the reason why the fields are not wrapped in [`Option`].
+pub struct NamingOptions {
+    pub tls_pkcs12_keystore_name: String,
+    pub tls_pkcs12_truststore_name: String,
+    pub tls_pem_cert_name: String,
+    pub tls_pem_key_name: String,
+    pub tls_pem_ca_name: String,
 }
 
 #[derive(Snafu, Debug)]

--- a/rust/operator-binary/src/format/well_known.rs
+++ b/rust/operator-binary/src/format/well_known.rs
@@ -109,7 +109,7 @@ impl WellKnownSecretData {
     pub fn convert_to(
         self,
         to: SecretFormat,
-        compat: &CompatibilityOptions,
+        compat: CompatibilityOptions,
     ) -> Result<Self, ConvertError> {
         convert::convert(self, to, compat)
     }
@@ -118,8 +118,16 @@ impl WellKnownSecretData {
 /// Options that some (legacy) applications require to ensure compatibility.
 ///
 /// The expectation is that this will be unset the vast majority of the time.
-#[derive(Default)]
+#[derive(Debug, Default, Deserialize)]
 pub struct CompatibilityOptions {
+    /// The password used to encrypt the TLS PKCS#12 keystore
+    ///
+    /// Required for some applications that misbehave with blank keystore passwords (such as Hadoop).
+    /// Has no effect if `format` is not `tls-pkcs12`.
+    #[serde(
+        rename = "secrets.stackable.tech/format.compatibility.tls-pkcs12.password",
+        default
+    )]
     pub tls_pkcs12_password: Option<String>,
 }
 

--- a/tests/templates/kuttl/tls/consumer.yaml.j2
+++ b/tests/templates/kuttl/tls/consumer.yaml.j2
@@ -15,14 +15,20 @@ spec:
           args:
             - -c
             - |
+{% if test_scenario['values']['custom-secret-names'] %}
+              CERT_NAME=custom-tls.crt
+{% else %}
+              CERT_NAME=tls.crt
+{% endif %}
+            - |
               set -euo pipefail
               ls -la /stackable/tls-3d
               ls -la /stackable/tls-42h
 
-              cat /stackable/tls-3d/tls.crt | openssl x509 -noout -text
-              cat /stackable/tls-42h/tls.crt | openssl x509 -noout -text
+              cat "/stackable/tls-3d/$CERT_NAME" | openssl x509 -noout -text
+              cat "/stackable/tls-42h/$CERT_NAME" | openssl x509 -noout -text
 
-              notAfter=`cat /stackable/tls-3d/tls.crt | openssl x509 -noout -enddate| sed -e 's#notAfter=##'`
+              notAfter=$(cat /stackable/tls-3d/$CERT_NAME | openssl x509 -noout -enddate| sed -e 's#notAfter=##')
               notAfterDate=`date -d "${notAfter}" '+%s'`
               nowDate=`date '+%s'`
               diff="$((${notAfterDate}-${nowDate}))"
@@ -30,7 +36,7 @@ spec:
               if test "${diff}" -lt "$((57*3600))"; then echo "Cert had a lifetime of less than 57 hours!" && exit 1; fi
               if test "${diff}" -gt "$((72*3600))"; then echo "Cert had a lifetime of greater than 72 hours!" && exit 1; fi
 
-              notAfter=`cat /stackable/tls-42h/tls.crt | openssl x509 -noout -enddate| sed -e 's#notAfter=##'`
+              notAfter=$(cat /stackable/tls-42h/$CERT_NAME | openssl x509 -noout -enddate| sed -e 's#notAfter=##')
               notAfterDate=`date -d "${notAfter}" '+%s'`
               nowDate=`date '+%s'`
               diff="$((${notAfterDate}-${nowDate}))"
@@ -38,8 +44,8 @@ spec:
               if test "${diff}" -lt "$((33*3600))"; then echo "Cert had a lifetime of less than 33 hours!" && exit 1; fi
               if test "${diff}" -gt "$((42*3600))"; then echo "Cert had a lifetime of greater than 42 hours!" && exit 1; fi
 
-              cat /stackable/tls-3d/tls.crt | openssl x509 -noout -text | grep "DNS:my-tls-service.$NAMESPACE.svc.cluster.local"
-              cat /stackable/tls-42h/tls.crt | openssl x509 -noout -text | grep "DNS:my-tls-service.$NAMESPACE.svc.cluster.local"
+              cat "/stackable/tls-3d/$CERT_NAME" | openssl x509 -noout -text | grep "DNS:my-tls-service.$NAMESPACE.svc.cluster.local"
+              cat "/stackable/tls-42h/$CERT_NAME" | openssl x509 -noout -text | grep "DNS:my-tls-service.$NAMESPACE.svc.cluster.local"
           volumeMounts:
             - mountPath: /stackable/tls-3d
               name: tls-3d
@@ -54,6 +60,9 @@ spec:
                   secrets.stackable.tech/class: tls-$NAMESPACE
                   secrets.stackable.tech/scope: node,pod,service=my-tls-service
                   secrets.stackable.tech/backend.autotls.cert.lifetime: 3d
+{% if test_scenario['values']['custom-secret-names'] %}
+                  secrets.stackable.tech/format.tls-pem.cert-name: custom-tls.crt
+{% endif %}
               spec:
                 storageClassName: secrets.stackable.tech
                 accessModes:
@@ -69,6 +78,9 @@ spec:
                   secrets.stackable.tech/class: tls-$NAMESPACE-42h
                   secrets.stackable.tech/scope: node,pod,service=my-tls-service
                   secrets.stackable.tech/backend.autotls.cert.lifetime: 31d
+{% if test_scenario['values']['custom-secret-names'] %}
+                  secrets.stackable.tech/format.tls-pem.cert-name: custom-tls.crt
+{% endif %}
               spec:
                 storageClassName: secrets.stackable.tech
                 accessModes:

--- a/tests/templates/kuttl/tls/consumer.yaml.j2
+++ b/tests/templates/kuttl/tls/consumer.yaml.j2
@@ -17,8 +17,10 @@ spec:
             - |
 {% if test_scenario['values']['custom-secret-names'] %}
               CERT_NAME=custom-tls.crt
+              CA_NAME=custom-ca.crt
 {% else %}
               CERT_NAME=tls.crt
+              CA_NAME=ca.crt
 {% endif %}
             - |
               set -euo pipefail
@@ -52,7 +54,7 @@ spec:
                   subject=$1
 
                   while openssl x509 -subject -noout; do :; done \
-                      < /stackable/tls-3d/ca.crt \
+                      < "/stackable/tls-3d/$CA_NAME" \
                       | grep --line-regexp "subject=CN *= *$subject"
               }
 
@@ -81,6 +83,7 @@ spec:
                   secrets.stackable.tech/backend.autotls.cert.lifetime: 3d
 {% if test_scenario['values']['custom-secret-names'] %}
                   secrets.stackable.tech/format.tls-pem.cert-name: custom-tls.crt
+                  secrets.stackable.tech/format.tls-pem.ca-name: custom-ca.crt
 {% endif %}
               spec:
                 storageClassName: secrets.stackable.tech
@@ -99,6 +102,7 @@ spec:
                   secrets.stackable.tech/backend.autotls.cert.lifetime: 31d
 {% if test_scenario['values']['custom-secret-names'] %}
                   secrets.stackable.tech/format.tls-pem.cert-name: custom-tls.crt
+                  secrets.stackable.tech/format.tls-pem.ca-name: custom-ca.crt
 {% endif %}
               spec:
                 storageClassName: secrets.stackable.tech

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -15,6 +15,10 @@ dimensions:
       - 2048
       - 3072
       # - 4096
+  - name: custom-secret-names
+    values:
+      - false
+      - true
 tests:
   - name: kerberos
     dimensions:
@@ -30,6 +34,7 @@ tests:
       - openshift
   - name: tls
     dimensions:
+      - custom-secret-names
       - rsa-key-length
       - openshift
   - name: cert-manager-tls


### PR DESCRIPTION
This PR adds support to customize the secret file names using `secrets.stackable.tech` annotations on the volume. The following attributes were added:

- `secrets.stackable.tech/format.tls-pkcs12.keystore-name`
- `secrets.stackable.tech/format.tls-pkcs12.truststore-name`
- `secrets.stackable.tech/format.tls-pem.cert-name`
- `secrets.stackable.tech/format.tls-pem.key-name`
- `secrets.stackable.tech/format.tls-pem.ca-name`

This came up in demo testing during the 25.3.0 SPD release, see https://github.com/stackabletech/demos/issues/157#issuecomment-2729108153.

This PR adds a new test dimension which is used in the `tls` tests. All adjusted tests pass:

```
--- PASS: kuttl (98.75s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/tls_openshift-false_rsa-key-length-3072_custom-secret-names-False (18.34s)
        --- PASS: kuttl/harness/tls_openshift-false_rsa-key-length-2048_custom-secret-names-True (7.51s)
        --- PASS: kuttl/harness/tls_openshift-false_rsa-key-length-3072_custom-secret-names-True (16.37s)
        --- PASS: kuttl/harness/tls_openshift-false_rsa-key-length-2048_custom-secret-names-False (8.31s)
        --- PASS: kuttl/harness/cert-manager-tls_openshift-false (98.73s)
PASS
```