### PR TITLE
feat!: Use `Tracing::pre_configured` from stackable-telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,17 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Replace stackable-operator `initialize_logging` with stackable-telemetry `Tracing` ([#581]).
-  - BREAKING: operator-binary: The file log directory was set by `SECRET_PROVISIONER_LOG_DIRECTORY`,
-    and is now set by `ROLLING_LOGS` (or via `--rolling-logs <DIRECTORY>`).
-  - BREAKING: olm-deployer: The file log directory was set by `STKBL_SECRET_OLM_DEPLOYER_LOG_DIRECTORY`,
-    and is now set by `ROLLING_LOGS` (or via `--rolling-logs <DIRECTORY>`).
+- BREAKING: Replace stackable-operator `initialize_logging` with stackable-telemetry `Tracing` ([#581], [#587]).
+  - operator-binary:
+    - The console log level was set by `SECRET_PROVISIONER_LOG`, and is now set by `CONSOLE_LOG`.
+    - The file log level was set by `SECRET_PROVISIONER_LOG`, and is now set by `FILE_LOG`.
+    - The file log directory was set by `SECRET_PROVISIONER_LOG_DIRECTORY`, and is now set
+      by `ROLLING_LOGS_DIR` (or via `--rolling-logs <DIRECTORY>`).
+  - olm-deployer:
+    - The console log level was set by `STKBL_SECRET_OLM_DEPLOYER_LOG`, and is now set by `CONSOLE_LOG`.
+    - The file log level was set by `STKBL_SECRET_OLM_DEPLOYER_LOG`, and is now set by `FILE_LOG`.
+    - The file log directory was set by `STKBL_SECRET_OLM_DEPLOYER_LOG_DIRECTORY`, and is now set
+      by `ROLLING_LOGS_DIR` (or via `--rolling-logs <DIRECTORY>`).
   - Replace stackable-operator `print_startup_string` with `tracing::info!` with fields.
 
 ### Fixed
@@ -30,6 +36,7 @@ All notable changes to this project will be documented in this file.
 [#572]: https://github.com/stackabletech/secret-operator/pull/572
 [#581]: https://github.com/stackabletech/secret-operator/pull/581
 [#586]: https://github.com/stackabletech/secret-operator/pull/586
+[#587]: https://github.com/stackabletech/secret-operator/pull/587
 
 ## [25.3.0] - 2025-03-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1621,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-version"
+version = "0.1.2"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
+dependencies = [
+ "darling",
+ "regex",
+ "snafu 0.8.5",
+]
+
+[[package]]
 name = "krb5"
 version = "0.0.0-dev"
 dependencies = [
@@ -2005,23 +2024,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "olm-deployer"
-version = "0.0.0-dev"
-dependencies = [
- "anyhow",
- "built",
- "clap",
- "serde",
- "serde_json",
- "serde_yaml",
- "stackable-operator",
- "stackable-telemetry",
- "tokio",
- "tracing",
- "walkdir",
 ]
 
 [[package]]
@@ -3065,8 +3067,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.89.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.89.1#cd73728af410c52972b9a9a3ba1302bcdb574d04"
+version = "0.91.1"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
 dependencies = [
  "chrono",
  "clap",
@@ -3090,6 +3092,8 @@ dependencies = [
  "snafu 0.8.5",
  "stackable-operator-derive",
  "stackable-shared",
+ "stackable-telemetry",
+ "stackable-versioned",
  "strum",
  "time",
  "tokio",
@@ -3102,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.89.1#cd73728af410c52972b9a9a3ba1302bcdb574d04"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3135,7 +3139,6 @@ dependencies = [
  "stackable-krb5-provision-keytab",
  "stackable-operator",
  "stackable-secret-operator-crd-utils",
- "stackable-telemetry",
  "strum",
  "sys-mount",
  "tempfile",
@@ -3159,9 +3162,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "stackable-secret-operator-olm-deployer"
+version = "0.0.0-dev"
+dependencies = [
+ "anyhow",
+ "built",
+ "clap",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "stackable-operator",
+ "tokio",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
 name = "stackable-shared"
 version = "0.0.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.89.1#cd73728af410c52972b9a9a3ba1302bcdb574d04"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
 dependencies = [
  "kube",
  "semver",
@@ -3172,10 +3191,11 @@ dependencies = [
 
 [[package]]
 name = "stackable-telemetry"
-version = "0.4.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-telemetry-0.4.0#52bdee5749e217005025d07f33c7020931c31d91"
+version = "0.5.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
 dependencies = [
  "axum 0.8.3",
+ "clap",
  "futures-util",
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -3183,12 +3203,37 @@ dependencies = [
  "opentelemetry_sdk",
  "pin-project",
  "snafu 0.8.5",
+ "strum",
  "tokio",
  "tower 0.5.2",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "stackable-versioned"
+version = "0.7.1"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
+dependencies = [
+ "stackable-versioned-macros",
+]
+
+[[package]]
+name = "stackable-versioned-macros"
+version = "0.7.1"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14"
+dependencies = [
+ "convert_case",
+ "darling",
+ "itertools 0.14.0",
+ "k8s-openapi",
+ "k8s-version",
+ "kube",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3712,6 +3757,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -58,16 +58,6 @@ rec {
       # File a bug if you depend on any for non-debug work!
       debug = internal.debugCrate { inherit packageId; };
     };
-    "olm-deployer" = rec {
-      packageId = "olm-deployer";
-      build = internal.buildRustCrateWithFeatures {
-        packageId = "olm-deployer";
-      };
-
-      # Debug support which might change between releases.
-      # File a bug if you depend on any for non-debug work!
-      debug = internal.debugCrate { inherit packageId; };
-    };
     "stackable-krb5-provision-keytab" = rec {
       packageId = "stackable-krb5-provision-keytab";
       build = internal.buildRustCrateWithFeatures {
@@ -92,6 +82,16 @@ rec {
       packageId = "stackable-secret-operator-crd-utils";
       build = internal.buildRustCrateWithFeatures {
         packageId = "stackable-secret-operator-crd-utils";
+      };
+
+      # Debug support which might change between releases.
+      # File a bug if you depend on any for non-debug work!
+      debug = internal.debugCrate { inherit packageId; };
+    };
+    "stackable-secret-operator-olm-deployer" = rec {
+      packageId = "stackable-secret-operator-olm-deployer";
+      build = internal.buildRustCrateWithFeatures {
+        packageId = "stackable-secret-operator-olm-deployer";
       };
 
       # Debug support which might change between releases.
@@ -1834,6 +1834,25 @@ rec {
           "syn" = [ "dep:syn" ];
         };
         resolvedDefaultFeatures = [ "default" ];
+      };
+      "convert_case" = rec {
+        crateName = "convert_case";
+        version = "0.8.0";
+        edition = "2021";
+        sha256 = "17zqy79xlr1n7nc0n1mlnw5qpp8l2nbxrk13jixrhlavrbna1ams";
+        authors = [
+          "rutrum <dave@rutrum.net>"
+        ];
+        dependencies = [
+          {
+            name = "unicode-segmentation";
+            packageId = "unicode-segmentation";
+          }
+        ];
+        features = {
+          "rand" = [ "dep:rand" ];
+          "random" = [ "rand" ];
+        };
       };
       "core-foundation 0.10.0" = rec {
         crateName = "core-foundation";
@@ -5113,6 +5132,40 @@ rec {
         };
         resolvedDefaultFeatures = [ "schemars" "v1_32" ];
       };
+      "k8s-version" = rec {
+        crateName = "k8s-version";
+        version = "0.1.2";
+        edition = "2024";
+        workspace_member = null;
+        src = pkgs.fetchgit {
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
+        };
+        libName = "k8s_version";
+        authors = [
+          "Stackable GmbH <info@stackable.de>"
+        ];
+        dependencies = [
+          {
+            name = "darling";
+            packageId = "darling";
+            optional = true;
+          }
+          {
+            name = "regex";
+            packageId = "regex";
+          }
+          {
+            name = "snafu";
+            packageId = "snafu 0.8.5";
+          }
+        ];
+        features = {
+          "darling" = [ "dep:darling" ];
+        };
+        resolvedDefaultFeatures = [ "darling" ];
+      };
       "krb5" = rec {
         crateName = "krb5";
         version = "0.0.0-dev";
@@ -6516,75 +6569,6 @@ rec {
           "write_std" = [ "write_core" "std" "indexmap?/std" "crc32fast?/std" ];
         };
         resolvedDefaultFeatures = [ "archive" "coff" "elf" "macho" "pe" "read_core" "unaligned" "xcoff" ];
-      };
-      "olm-deployer" = rec {
-        crateName = "olm-deployer";
-        version = "0.0.0-dev";
-        edition = "2021";
-        crateBin = [
-          {
-            name = "olm-deployer";
-            path = "src/main.rs";
-            requiredFeatures = [ ];
-          }
-        ];
-        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./rust/olm-deployer; };
-        authors = [
-          "Stackable GmbH <info@stackable.tech>"
-        ];
-        dependencies = [
-          {
-            name = "anyhow";
-            packageId = "anyhow";
-          }
-          {
-            name = "clap";
-            packageId = "clap";
-          }
-          {
-            name = "serde";
-            packageId = "serde";
-            features = [ "derive" ];
-          }
-          {
-            name = "serde_json";
-            packageId = "serde_json";
-          }
-          {
-            name = "serde_yaml";
-            packageId = "serde_yaml";
-          }
-          {
-            name = "stackable-operator";
-            packageId = "stackable-operator";
-            features = [ "time" ];
-          }
-          {
-            name = "stackable-telemetry";
-            packageId = "stackable-telemetry";
-          }
-          {
-            name = "tokio";
-            packageId = "tokio";
-            features = [ "full" ];
-          }
-          {
-            name = "tracing";
-            packageId = "tracing";
-          }
-          {
-            name = "walkdir";
-            packageId = "walkdir";
-          }
-        ];
-        buildDependencies = [
-          {
-            name = "built";
-            packageId = "built";
-            features = [ "chrono" "git2" ];
-          }
-        ];
-
       };
       "once_cell" = rec {
         crateName = "once_cell";
@@ -10017,7 +10001,7 @@ rec {
           {
             name = "stackable-operator";
             packageId = "stackable-operator";
-            features = [ "time" ];
+            features = [ "time" "telemetry" ];
           }
           {
             name = "stackable-secret-operator-crd-utils";
@@ -10041,13 +10025,13 @@ rec {
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.89.1";
+        version = "0.91.1";
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "cd73728af410c52972b9a9a3ba1302bcdb574d04";
-          sha256 = "1hrxrybc6197ibx0m2wfxlg5pdg4hanf6xvslzrhsp77a04pb0y9";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
         };
         libName = "stackable_operator";
         authors = [
@@ -10153,6 +10137,16 @@ rec {
             packageId = "stackable-shared";
           }
           {
+            name = "stackable-telemetry";
+            packageId = "stackable-telemetry";
+            features = [ "clap" ];
+          }
+          {
+            name = "stackable-versioned";
+            packageId = "stackable-versioned";
+            features = [ "k8s" ];
+          }
+          {
             name = "strum";
             packageId = "strum";
             features = [ "derive" ];
@@ -10187,9 +10181,11 @@ rec {
           }
         ];
         features = {
+          "default" = [ "telemetry" "versioned" ];
+          "full" = [ "time" "telemetry" "versioned" ];
           "time" = [ "dep:time" ];
         };
-        resolvedDefaultFeatures = [ "time" ];
+        resolvedDefaultFeatures = [ "default" "telemetry" "time" "versioned" ];
       };
       "stackable-operator-derive" = rec {
         crateName = "stackable-operator-derive";
@@ -10198,8 +10194,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "cd73728af410c52972b9a9a3ba1302bcdb574d04";
-          sha256 = "1hrxrybc6197ibx0m2wfxlg5pdg4hanf6xvslzrhsp77a04pb0y9";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -10316,15 +10312,11 @@ rec {
           {
             name = "stackable-operator";
             packageId = "stackable-operator";
-            features = [ "time" ];
+            features = [ "time" "telemetry" ];
           }
           {
             name = "stackable-secret-operator-crd-utils";
             packageId = "stackable-secret-operator-crd-utils";
-          }
-          {
-            name = "stackable-telemetry";
-            packageId = "stackable-telemetry";
           }
           {
             name = "strum";
@@ -10414,7 +10406,72 @@ rec {
           {
             name = "stackable-operator";
             packageId = "stackable-operator";
-            features = [ "time" ];
+            features = [ "time" "telemetry" ];
+          }
+        ];
+
+      };
+      "stackable-secret-operator-olm-deployer" = rec {
+        crateName = "stackable-secret-operator-olm-deployer";
+        version = "0.0.0-dev";
+        edition = "2021";
+        crateBin = [
+          {
+            name = "stackable-secret-operator-olm-deployer";
+            path = "src/main.rs";
+            requiredFeatures = [ ];
+          }
+        ];
+        src = lib.cleanSourceWith { filter = sourceFilter;  src = ./rust/olm-deployer; };
+        authors = [
+          "Stackable GmbH <info@stackable.tech>"
+        ];
+        dependencies = [
+          {
+            name = "anyhow";
+            packageId = "anyhow";
+          }
+          {
+            name = "clap";
+            packageId = "clap";
+          }
+          {
+            name = "serde";
+            packageId = "serde";
+            features = [ "derive" ];
+          }
+          {
+            name = "serde_json";
+            packageId = "serde_json";
+          }
+          {
+            name = "serde_yaml";
+            packageId = "serde_yaml";
+          }
+          {
+            name = "stackable-operator";
+            packageId = "stackable-operator";
+            features = [ "time" "telemetry" ];
+          }
+          {
+            name = "tokio";
+            packageId = "tokio";
+            features = [ "full" ];
+          }
+          {
+            name = "tracing";
+            packageId = "tracing";
+          }
+          {
+            name = "walkdir";
+            packageId = "walkdir";
+          }
+        ];
+        buildDependencies = [
+          {
+            name = "built";
+            packageId = "built";
+            features = [ "chrono" "git2" ];
           }
         ];
 
@@ -10426,8 +10483,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "cd73728af410c52972b9a9a3ba1302bcdb574d04";
-          sha256 = "1hrxrybc6197ibx0m2wfxlg5pdg4hanf6xvslzrhsp77a04pb0y9";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
         };
         libName = "stackable_shared";
         authors = [
@@ -10462,13 +10519,13 @@ rec {
       };
       "stackable-telemetry" = rec {
         crateName = "stackable-telemetry";
-        version = "0.4.0";
+        version = "0.5.0";
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "52bdee5749e217005025d07f33c7020931c31d91";
-          sha256 = "0hcm64fb2ngyalq8rci5lrr881prg023pq9cd1sfr79iynbr6a26";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
         };
         libName = "stackable_telemetry";
         authors = [
@@ -10478,6 +10535,12 @@ rec {
           {
             name = "axum";
             packageId = "axum 0.8.3";
+          }
+          {
+            name = "clap";
+            packageId = "clap";
+            optional = true;
+            features = [ "derive" "cargo" "env" ];
           }
           {
             name = "futures-util";
@@ -10509,6 +10572,11 @@ rec {
           {
             name = "snafu";
             packageId = "snafu 0.8.5";
+          }
+          {
+            name = "strum";
+            packageId = "strum";
+            features = [ "derive" ];
           }
           {
             name = "tokio";
@@ -10549,7 +10617,110 @@ rec {
             packageId = "tracing-opentelemetry";
           }
         ];
-
+        features = {
+          "clap" = [ "dep:clap" ];
+        };
+        resolvedDefaultFeatures = [ "clap" ];
+      };
+      "stackable-versioned" = rec {
+        crateName = "stackable-versioned";
+        version = "0.7.1";
+        edition = "2024";
+        workspace_member = null;
+        src = pkgs.fetchgit {
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
+        };
+        libName = "stackable_versioned";
+        authors = [
+          "Stackable GmbH <info@stackable.de>"
+        ];
+        dependencies = [
+          {
+            name = "stackable-versioned-macros";
+            packageId = "stackable-versioned-macros";
+          }
+        ];
+        features = {
+          "full" = [ "k8s" ];
+          "k8s" = [ "stackable-versioned-macros/k8s" ];
+        };
+        resolvedDefaultFeatures = [ "k8s" ];
+      };
+      "stackable-versioned-macros" = rec {
+        crateName = "stackable-versioned-macros";
+        version = "0.7.1";
+        edition = "2024";
+        workspace_member = null;
+        src = pkgs.fetchgit {
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "0f9b6f9669051e9c4f29e6e882acf3eff3ac3f14";
+          sha256 = "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw";
+        };
+        procMacro = true;
+        libName = "stackable_versioned_macros";
+        authors = [
+          "Stackable GmbH <info@stackable.de>"
+        ];
+        dependencies = [
+          {
+            name = "convert_case";
+            packageId = "convert_case";
+          }
+          {
+            name = "darling";
+            packageId = "darling";
+          }
+          {
+            name = "itertools";
+            packageId = "itertools 0.14.0";
+          }
+          {
+            name = "k8s-openapi";
+            packageId = "k8s-openapi";
+            optional = true;
+            usesDefaultFeatures = false;
+            features = [ "schemars" "v1_32" ];
+          }
+          {
+            name = "k8s-version";
+            packageId = "k8s-version";
+            features = [ "darling" ];
+          }
+          {
+            name = "kube";
+            packageId = "kube";
+            optional = true;
+            usesDefaultFeatures = false;
+            features = [ "client" "jsonpatch" "runtime" "derive" "rustls-tls" "ring" ];
+          }
+          {
+            name = "proc-macro2";
+            packageId = "proc-macro2";
+          }
+          {
+            name = "quote";
+            packageId = "quote";
+          }
+          {
+            name = "syn";
+            packageId = "syn 2.0.99";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "k8s-openapi";
+            packageId = "k8s-openapi";
+            usesDefaultFeatures = false;
+            features = [ "schemars" "v1_32" ];
+          }
+        ];
+        features = {
+          "full" = [ "k8s" ];
+          "k8s" = [ "dep:kube" "dep:k8s-openapi" ];
+        };
+        resolvedDefaultFeatures = [ "k8s" ];
       };
       "strsim" = rec {
         crateName = "strsim";
@@ -12486,6 +12657,19 @@ rec {
           "David Tolnay <dtolnay@gmail.com>"
         ];
 
+      };
+      "unicode-segmentation" = rec {
+        crateName = "unicode-segmentation";
+        version = "1.12.0";
+        edition = "2018";
+        sha256 = "14qla2jfx74yyb9ds3d2mpwpa4l4lzb9z57c6d2ba511458z5k7n";
+        libName = "unicode_segmentation";
+        authors = [
+          "kwantam <kwantam@gmail.com>"
+          "Manish Goregaokar <manishsmail@gmail.com>"
+        ];
+        features = {
+        };
       };
       "unicode-xid" = rec {
         crateName = "unicode-xid";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ edition = "2021"
 repository = "https://github.com/stackabletech/secret-operator"
 
 [workspace.dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.89.1", features = ["time"] }
-stackable-telemetry = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-telemetry-0.4.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", features = ["time", "telemetry"], tag = "stackable-operator-0.91.1" }
 
 anyhow = "1.0"
 async-trait = "0.1"

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,7 +1,10 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.89.1#stackable-operator-derive@0.3.1": "1hrxrybc6197ibx0m2wfxlg5pdg4hanf6xvslzrhsp77a04pb0y9",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.89.1#stackable-operator@0.89.1": "1hrxrybc6197ibx0m2wfxlg5pdg4hanf6xvslzrhsp77a04pb0y9",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.89.1#stackable-shared@0.0.1": "1hrxrybc6197ibx0m2wfxlg5pdg4hanf6xvslzrhsp77a04pb0y9",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-telemetry-0.4.0#stackable-telemetry@0.4.0": "0hcm64fb2ngyalq8rci5lrr881prg023pq9cd1sfr79iynbr6a26",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#k8s-version@0.1.2": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#stackable-operator-derive@0.3.1": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#stackable-operator@0.91.1": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#stackable-shared@0.0.1": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#stackable-telemetry@0.5.0": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#stackable-versioned-macros@0.7.1": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.91.1#stackable-versioned@0.7.1": "11zqwlwvfigca7lfsdch1wqd3vl694hff1avf6rhiawpnassj2cw",
   "git+https://github.com/stackabletech/product-config.git?tag=0.7.0#product-config@0.7.0": "0gjsm80g6r75pm3824dcyiz4ysq1ka4c1if6k1mjm9cnd5ym0gny"
 }

--- a/rust/olm-deployer/Cargo.toml
+++ b/rust/olm-deployer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "olm-deployer"
+name = "stackable-secret-operator-olm-deployer"
 description = "OLM deployment helper."
 version.workspace = true
 authors.workspace = true
@@ -10,7 +10,6 @@ publish = false
 
 [dependencies]
 stackable-operator.workspace = true
-stackable-telemetry.workspace = true
 
 anyhow.workspace = true
 clap.workspace = true

--- a/rust/olm-deployer/src/main.rs
+++ b/rust/olm-deployer/src/main.rs
@@ -18,12 +18,10 @@ mod owner;
 mod resources;
 mod tolerations;
 
-use std::ops::Deref as _;
-
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Parser;
 use stackable_operator::{
-    cli::{Command, RollingPeriod, TelemetryArguments},
+    cli::Command,
     client,
     k8s_openapi::api::{apps::v1::Deployment, rbac::v1::ClusterRole},
     kube::{
@@ -32,15 +30,11 @@ use stackable_operator::{
         core::GroupVersionKind,
         discovery::{ApiResource, Discovery, Scope},
     },
+    telemetry::{Tracing, tracing::TelemetryOptions},
     utils::cluster_info::KubernetesClusterInfoOpts,
 };
-use stackable_telemetry::{Tracing, tracing::settings::Settings};
-use tracing::level_filters::LevelFilter;
 
 pub const APP_NAME: &str = "stkbl-secret-olm-deployer";
-
-// TODO (@NickLarsenNZ): Change the variable to `CONSOLE_LOG`
-pub const ENV_VAR_CONSOLE_LOG: &str = "STKBL_SECRET_OLM_DEPLOYER_LOG";
 
 mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
@@ -76,7 +70,7 @@ struct OlmDeployerRun {
     dir: std::path::PathBuf,
 
     #[command(flatten)]
-    pub telemetry_arguments: TelemetryArguments,
+    pub telemetry_arguments: TelemetryOptions,
 
     #[command(flatten)]
     pub cluster_info_opts: KubernetesClusterInfoOpts,
@@ -94,43 +88,12 @@ async fn main() -> Result<()> {
         cluster_info_opts,
     }) = opts.cmd
     {
-        let _tracing_guard = Tracing::builder()
-            .service_name("secret-operator-olm-deployer")
-            .with_console_output((
-                ENV_VAR_CONSOLE_LOG,
-                LevelFilter::INFO,
-                !telemetry_arguments.no_console_output,
-            ))
-            // NOTE (@NickLarsenNZ): Before stackable-telemetry was used, the log directory was
-            // set via an env: `STKBL_SECRET_OLM_DEPLOYER_LOG_DIRECTORY`.
-            // See: https://github.com/stackabletech/operator-rs/blob/f035997fca85a54238c8de895389cc50b4d421e2/crates/stackable-operator/src/logging/mod.rs#L40
-            // Now it will be `ROLLING_LOGS` (or via `--rolling-logs <DIRECTORY>`).
-            .with_file_output(telemetry_arguments.rolling_logs.map(|log_directory| {
-                let rotation_period = telemetry_arguments
-                    .rolling_logs_period
-                    .unwrap_or(RollingPeriod::Never)
-                    .deref()
-                    .clone();
-
-                Settings::builder()
-                    .with_environment_variable(ENV_VAR_CONSOLE_LOG)
-                    .with_default_level(LevelFilter::INFO)
-                    .file_log_settings_builder(log_directory, "tracing-rs.json")
-                    .with_rotation_period(rotation_period)
-                    .build()
-            }))
-            .with_otlp_log_exporter((
-                "OTLP_LOG",
-                LevelFilter::DEBUG,
-                telemetry_arguments.otlp_logs,
-            ))
-            .with_otlp_trace_exporter((
-                "OTLP_TRACE",
-                LevelFilter::DEBUG,
-                telemetry_arguments.otlp_traces,
-            ))
-            .build()
-            .init()?;
+        // NOTE (@NickLarsenNZ): Before stackable-telemetry was used:
+        // - The console log level was set by `STKBL_SECRET_OLM_DEPLOYER_LOG`, and is now `CONSOLE_LOG` (when using Tracing::pre_configured).
+        // - The file log level was set by `STKBL_SECRET_OLM_DEPLOYER_LOG`, and is now set via `FILE_LOG` (when using Tracing::pre_configured).
+        // - The file log directory was set by `STKBL_SECRET_OLM_DEPLOYER_LOG_DIRECTORY`, and is now set by `ROLLING_LOGS_DIR` (or via `--rolling-logs <DIRECTORY>`).
+        let _tracing_guard =
+            Tracing::pre_configured(built_info::PKG_NAME, telemetry_arguments).init()?;
 
         tracing::info!(
             built_info.pkg_version = built_info::PKG_VERSION,

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -12,7 +12,6 @@ publish = false
 stackable-krb5-provision-keytab = { path = "../krb5-provision-keytab" }
 stackable-secret-operator-crd-utils = { path = "../crd-utils" }
 stackable-operator.workspace = true
-stackable-telemetry.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true


### PR DESCRIPTION
# Description

**Use `Tracing::pre_configured` from stackable-telemetry**

#### operator-binary

Breaking changes:

- The console log level was set by `SECRET_PROVISIONER_LOG`, and is now set by `CONSOLE_LOG`.
- The file log level was set by `SECRET_PROVISIONER_LOG`, and is now set by `FILE_LOG`.
- The file log directory was previously changed to `ROLLING_LOGS`, but has been updated to `ROLLING_LOGS_DIR`.

#### olm-deployer

Breaking changes:

- The console log level was set by `STKBL_SECRET_OLM_DEPLOYER_LOG`, and is now set by `CONSOLE_LOG`.
- The file log level was set by `STKBL_SECRET_OLM_DEPLOYER_LOG`, and is now set by `FILE_LOG`.
- The file log directory was previously changed to `ROLLING_LOGS`, but has been updated to `ROLLING_LOGS_DIR`.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
