### PR TITLE
chore: Bump csi-provisioner to 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
     - The file log directory was set by `STKBL_SECRET_OLM_DEPLOYER_LOG_DIRECTORY`, and is now set
       by `FILE_LOG_DIRECTORY` (or via `--file-log-directory <DIRECTORY>`).
   - Replace stackable-operator `print_startup_string` with `tracing::info!` with fields.
+- Upgrade csi-provisioner to 5.2.0 ([#594]).
 
 ### Fixed
 
@@ -42,6 +43,7 @@ All notable changes to this project will be documented in this file.
 [#586]: https://github.com/stackabletech/secret-operator/pull/586
 [#587]: https://github.com/stackabletech/secret-operator/pull/587
 [#591]: https://github.com/stackabletech/secret-operator/pull/591
+[#594]: https://github.com/stackabletech/secret-operator/pull/594
 
 ## [25.3.0] - 2025-03-21
 

--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -8,7 +8,7 @@ image:
 csiProvisioner:
   image:
     repository: oci.stackable.tech/sdp/sig-storage/csi-provisioner
-    tag: v5.1.0
+    tag: v5.2.0
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1064

Note: Image mirrored by https://github.com/stackabletech/docker-images/actions/runs/14833003316

## Definition of Done Checklist

> [!TIP]
> Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant

Please make sure all these things are done and tick the boxes

# Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

# Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

# Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated

