### PR TITLE
chore(helm)!: Rearrange values to be somewhat consistent with the listener-operator value changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,23 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Support exporting the TrustStore CA certificate information to Secrets or ConfigMaps ([#597]).
+- New helm value for `priorityClassName` ([#641]).
 
 ### Changed
 
 - Version CRD structs and enums as v1alpha1 ([#636]).
+- BREAKING: Rearrange values to be somewhat consistent with the listener-operator value changes ([#641]).
+  - `image.repository` has been moved to `secretOperator.image.repository`.
+  - `image.tag` has been moved to `secretOperator.image.tag`.
+  - `image.pullPolicy` has been moved to `secretOperator.image.pullPolicy`.
+  - `csiProvisioner` values have been moved to `externalProvisioner`.
+  - `csiNodeDriverRegistrar` values have been moved to `nodeDriverRegistrar`.
+  - `node.driver` values have been moved to `secretOperator`.
+  - `securityContext` values have been moved to `secretOperator.securityContext`.
 
 [#597]: https://github.com/stackabletech/secret-operator/pull/597
 [#636]: https://github.com/stackabletech/secret-operator/pull/636
+[#641]: https://github.com/stackabletech/secret-operator/pull/641
 
 ## [25.7.0] - 2025-07-23
 

--- a/deploy/helm/secret-operator/templates/daemonset.yaml
+++ b/deploy/helm/secret-operator/templates/daemonset.yaml
@@ -28,11 +28,11 @@ spec:
       containers:
         - name: {{ include "operator.appname" . }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+            {{- toYaml .Values.secretOperator.securityContext | nindent 12 }}
+          image: "{{ .Values.secretOperator.image.repository }}:{{ .Values.secretOperator.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.secretOperator.image.pullPolicy }}
           resources:
-            {{ .Values.node.driver.resources | toYaml | nindent 12 }}
+            {{ .Values.secretOperator.resources | toYaml | nindent 12 }}
           env:
             # The following env vars are passed as clap (think CLI) arguments to the operator.
             # They are picked up by clap using the structs defied in the operator.
@@ -42,7 +42,7 @@ spec:
             - name: CSI_ENDPOINT
               value: /csi/csi.sock
             - name: PRIVILEGED
-              value: {{ .Values.securityContext.privileged | quote }}
+              value: {{ .Values.secretOperator.securityContext.privileged | quote }}
 
             # Sometimes products need to know the operator image, e.g. the opa-bundle-builder OPA
             # sidecar uses the operator image.
@@ -81,16 +81,16 @@ spec:
               mountPath: /csi
             - name: mountpoint
               mountPath: {{ .Values.kubeletDir }}/pods
-              {{- if .Values.securityContext.privileged }}
+              {{- if .Values.secretOperator.securityContext.privileged }}
               mountPropagation: Bidirectional
               {{- end }}
             - name: tmp
               mountPath: /tmp
         - name: external-provisioner
-          image: "{{ .Values.csiProvisioner.image.repository }}:{{ .Values.csiProvisioner.image.tag }}"
-          imagePullPolicy: {{ .Values.csiProvisioner.image.pullPolicy }}
+          image: "{{ .Values.externalProvisioner.image.repository }}:{{ .Values.externalProvisioner.image.tag }}"
+          imagePullPolicy: {{ .Values.externalProvisioner.image.pullPolicy }}
           resources:
-            {{ .Values.csiProvisioner.resources | toYaml | nindent 12 }}
+            {{ .Values.externalProvisioner.resources | toYaml | nindent 12 }}
           args:
             - --csi-address=/csi/csi.sock
             - --feature-gates=Topology=true
@@ -99,10 +99,10 @@ spec:
             - name: csi
               mountPath: /csi
         - name: node-driver-registrar
-          image: "{{ .Values.csiNodeDriverRegistrar.image.repository }}:{{ .Values.csiNodeDriverRegistrar.image.tag }}"
-          imagePullPolicy: {{ .Values.csiNodeDriverRegistrar.image.pullPolicy }}
+          image: "{{ .Values.nodeDriverRegistrar.image.repository }}:{{ .Values.nodeDriverRegistrar.image.tag }}"
+          imagePullPolicy: {{ .Values.nodeDriverRegistrar.image.pullPolicy }}
           resources:
-            {{ .Values.csiNodeDriverRegistrar.resources | toYaml | nindent 12 }}
+            {{ .Values.nodeDriverRegistrar.resources | toYaml | nindent 12 }}
           args:
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path={{ .Values.kubeletDir }}/plugins/secrets.stackable.tech/csi.sock

--- a/deploy/helm/secret-operator/templates/daemonset.yaml
+++ b/deploy/helm/secret-operator/templates/daemonset.yaml
@@ -137,3 +137,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -83,6 +83,8 @@ tolerations: []
 
 affinity: {}
 
+# priorityClassName: ...
+
 # When running on a non-default Kubernetes cluster domain, the cluster domain can be configured here.
 # See the https://docs.stackable.tech/home/stable/guides/kubernetes-cluster-domain guide for details.
 # kubernetesClusterDomain: my-cluster.local

--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -1,11 +1,9 @@
 # Default values for secret-operator.
 ---
 image:
-  repository: oci.stackable.tech/sdp/secret-operator
-  pullPolicy: IfNotPresent
   pullSecrets: []
 
-csiProvisioner:
+externalProvisioner:
   image:
     repository: oci.stackable.tech/sdp/sig-storage/csi-provisioner
     tag: v5.2.0
@@ -17,7 +15,7 @@ csiProvisioner:
     limits:
       cpu: 100m
       memory: 128Mi
-csiNodeDriverRegistrar:
+nodeDriverRegistrar:
   image:
     repository: oci.stackable.tech/sdp/sig-storage/csi-node-driver-registrar
     tag: v2.13.0
@@ -30,16 +28,33 @@ csiNodeDriverRegistrar:
       cpu: 100m
       memory: 128Mi
 
-node:
-  driver:
-    # Resources of the secret-operator container itself
-    resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
-      requests:
-        cpu: 100m
-        memory: 128Mi
+secretOperator:
+  image:
+    repository: oci.stackable.tech/sdp/secret-operator
+    # tag: 0.0.0-dev
+    pullPolicy: IfNotPresent
+  # Resources of the secret-operator container itself
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  securityContext:
+    # secret-operator requires root permissions
+    runAsUser: 0
+    # It is strongly recommended to run secret-operator as a privileged container, since
+    # it enables additional protections for the secret contents.
+    # Unprivileged mode is EXPERIMENTAL and requires manual migration for an existing cluster.
+    privileged: true
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
 
 nameOverride: ""
 fullnameOverride: ""
@@ -61,20 +76,6 @@ labels:
 
 podSecurityContext: {}
   # fsGroup: 2000
-
-securityContext:
-  # secret-operator requires root permissions
-  runAsUser: 0
-  # It is strongly recommended to run secret-operator as a privileged container, since
-  # it enables additional protections for the secret contents.
-  # Unprivileged mode is EXPERIMENTAL and requires manual migration for an existing cluster.
-  privileged: true
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 nodeSelector: {}
 


### PR DESCRIPTION
## Description

Part of stackabletech/issues#763

> [!NOTE]
> These changes aren't exactly consistent with listener-operator changes from https://github.com/stackabletech/listener-operator/pull/334, but are a step towards consistency, and make it easier should we decide to split secret-operator into a CSI Provisioner Deployment and CSI Node Driver DaemonSet.

## Helm Values changes

> [!CAUTION]
> The original values are no longer valid.

- `image.repository` has been moved to `secretOperator.image.repository`.
- `image.tag` has been moved to `secretOperator.image.tag`.
- `image.pullPolicy` has been moved to `secretOperator.image.pullPolicy`.
- `csiProvisioner` values have been moved to `externalProvisioner`.
- `csiNodeDriverRegistrar` values have been moved to `nodeDriverRegistrar`.
- `node.driver` values have been moved to `secretOperator`.
- `securityContext` values have been moved to `secretOperator.securityContext`.

> [!TIP]
> In addition, the following new value is available.
> This is part of https://github.com/stackabletech/issues/issues/765.

- `priorityClassName`

<details>

```diff
diff --git a/deploy/helm/secret-operator/values.yaml b/deploy/helm/secret-operator/values.yaml
index c920d3b..3d8c6dc 100644
--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -1,11 +1,9 @@
 # Default values for secret-operator.
 ---
 image:
-  repository: oci.stackable.tech/sdp/secret-operator
-  pullPolicy: IfNotPresent
   pullSecrets: []
 
-csiProvisioner:
+externalProvisioner:
   image:
     repository: oci.stackable.tech/sdp/sig-storage/csi-provisioner
     tag: v5.2.0
@@ -17,7 +15,7 @@ csiProvisioner:
     limits:
       cpu: 100m
       memory: 128Mi
-csiNodeDriverRegistrar:
+nodeDriverRegistrar:
   image:
     repository: oci.stackable.tech/sdp/sig-storage/csi-node-driver-registrar
     tag: v2.13.0
@@ -30,16 +28,33 @@ csiNodeDriverRegistrar:
       cpu: 100m
       memory: 128Mi
 
-node:
-  driver:
-    # Resources of the secret-operator container itself
-    resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
-      requests:
-        cpu: 100m
-        memory: 128Mi
+secretOperator:
+  image:
+    repository: oci.stackable.tech/sdp/secret-operator
+    # tag: 0.0.0-dev
+    pullPolicy: IfNotPresent
+  # Resources of the secret-operator container itself
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  securityContext:
+    # secret-operator requires root permissions
+    runAsUser: 0
+    # It is strongly recommended to run secret-operator as a privileged container, since
+    # it enables additional protections for the secret contents.
+    # Unprivileged mode is EXPERIMENTAL and requires manual migration for an existing cluster.
+    privileged: true
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
 
 nameOverride: ""
 fullnameOverride: ""
@@ -62,26 +77,14 @@ labels:
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
-  # secret-operator requires root permissions
-  runAsUser: 0
-  # It is strongly recommended to run secret-operator as a privileged container, since
-  # it enables additional protections for the secret contents.
-  # Unprivileged mode is EXPERIMENTAL and requires manual migration for an existing cluster.
-  privileged: true
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
-
 nodeSelector: {}
 
 tolerations: []
 
 affinity: {}
 
+# priorityClassName: ...
+
 # When running on a non-default Kubernetes cluster domain, the cluster domain can be configured here.
 # See the https://docs.stackable.tech/home/stable/guides/kubernetes-cluster-domain guide for details.
 # kubernetesClusterDomain: my-cluster.local
```

</details>
