### PR TITLE
fix: Use correct image in Helm values.yaml

### DIFF
--- a/deploy/helm/secret-operator/values.yaml
+++ b/deploy/helm/secret-operator/values.yaml
@@ -2,7 +2,7 @@
 ---
 # Used by both the Controller Service and Node Service containers
 image:
-  repository: oci.stackable.tech/sdp/listener-operator
+  repository: oci.stackable.tech/sdp/secret-operator
   # tag: 0.0.0-dev
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
This was accidentally introduced in #645.