### PR TITLE
fix: Fix broken link to SecretClass CRD docs (#697)

### DIFF
--- a/docs/modules/secret-operator/partials/nav.adoc
+++ b/docs/modules/secret-operator/partials/nav.adoc
@@ -12,7 +12,7 @@
 * xref:secret-operator:security.adoc[]
 * xref:secret-operator:reference/index.adoc[]
 ** xref:secret-operator:reference/crds.adoc[]
-*** {crd-docs}/secrets.stackable.tech/secretclass/v1alpha1/[SecretClass {external-link-icon}^]
+*** {crd-docs}/secrets.stackable.tech/secretclass/v1alpha2/[SecretClass {external-link-icon}^]
 *** {crd-docs}/secrets.stackable.tech/truststore/v1alpha1/[TrustStore {external-link-icon}^]
 ** xref:secret-operator:reference/commandline-parameters.adoc[]
 * xref:secret-operator:troubleshooting.adoc[]


### PR DESCRIPTION
## Description

Backport of https://github.com/stackabletech/secret-operator/commit/4703adaf4a4e5ff79842413431a79799d4aeb716 into `release-25.11`

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
