### PR TITLE
fix: redact pkcs12 password in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ All notable changes to this project will be documented in this file.
 
 - Document Helm deployed RBAC permissions and remove unnecessary permissions ([#693]).
 
+### Fixed
+
+- Redact the user-provided PKCS#12 keystore password in operator logs. ([#706]).
+
 [#693]: https://github.com/stackabletech/secret-operator/pull/693
+[#706]: https://github.com/stackabletech/secret-operator/pull/706
 
 ## [26.3.0] - 2026-03-16
 

--- a/rust/operator-binary/src/format/convert.rs
+++ b/rust/operator-binary/src/format/convert.rs
@@ -22,7 +22,10 @@ pub fn convert(
         (WellKnownSecretData::TlsPem(pem), SecretFormat::TlsPkcs12) => {
             Ok(WellKnownSecretData::TlsPkcs12(convert_tls_to_pkcs12(
                 pem,
-                compat.tls_pkcs12_password.as_deref().unwrap_or_default(),
+                compat
+                    .tls_pkcs12_password
+                    .as_deref()
+                    .map_or("", String::as_str),
             )?))
         }
 

--- a/rust/operator-binary/src/format/convert.rs
+++ b/rust/operator-binary/src/format/convert.rs
@@ -22,10 +22,7 @@ pub fn convert(
         (WellKnownSecretData::TlsPem(pem), SecretFormat::TlsPkcs12) => {
             Ok(WellKnownSecretData::TlsPkcs12(convert_tls_to_pkcs12(
                 pem,
-                compat
-                    .tls_pkcs12_password
-                    .as_deref()
-                    .map_or("", String::as_str),
+                &compat.tls_pkcs12_password.unwrap_or_default(),
             )?))
         }
 

--- a/rust/operator-binary/src/format/well_known.rs
+++ b/rust/operator-binary/src/format/well_known.rs
@@ -4,7 +4,10 @@ use stackable_operator::schemars::{self, JsonSchema};
 use strum::EnumDiscriminants;
 
 use super::{ConvertError, SecretFiles, convert};
-use crate::{backend::ProvisionParts, utils::ResultExt};
+use crate::{
+    backend::ProvisionParts,
+    utils::{ResultExt, Unloggable},
+};
 
 const FILE_PEM_CERT_CERT: &str = "tls.crt";
 const FILE_PEM_CERT_KEY: &str = "tls.key";
@@ -168,7 +171,7 @@ pub struct CompatibilityOptions {
         rename = "secrets.stackable.tech/format.compatibility.tls-pkcs12.password",
         default
     )]
-    pub tls_pkcs12_password: Option<String>,
+    pub tls_pkcs12_password: Option<Unloggable<String>>,
 }
 
 /// Options to customize the well-known format file names.

--- a/rust/operator-binary/src/utils.rs
+++ b/rust/operator-binary/src/utils.rs
@@ -179,6 +179,7 @@ pub fn asn1time_to_offsetdatetime(asn: &Asn1TimeRef) -> Result<OffsetDateTime, A
 
 /// Wrapper for (mostly) secret values that should not be logged.
 // When/if migrating to Valuable, provide a dummy implementation of Value too
+#[derive(Default)]
 pub struct Unloggable<T>(pub T);
 
 impl<T> Debug for Unloggable<T> {
@@ -198,6 +199,12 @@ impl<T> Deref for Unloggable<T> {
 impl<T> DerefMut for Unloggable<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for Unloggable<T> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        T::deserialize(deserializer).map(Unloggable)
     }
 }
 

--- a/rust/operator-binary/src/utils.rs
+++ b/rust/operator-binary/src/utils.rs
@@ -179,8 +179,16 @@ pub fn asn1time_to_offsetdatetime(asn: &Asn1TimeRef) -> Result<OffsetDateTime, A
 
 /// Wrapper for (mostly) secret values that should not be logged.
 // When/if migrating to Valuable, provide a dummy implementation of Value too
-#[derive(Default)]
 pub struct Unloggable<T>(pub T);
+
+impl<T> Default for Unloggable<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self(T::default())
+    }
+}
 
 impl<T> Debug for Unloggable<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
## Description

The CSI `node_publish_volume` handler logs the full `SecretVolumeSelector` in the `issuing secret for Pod` `INFO` event. `CompatibilityOptions` derived `Debug`, so the user-provided PKCS#12 keystore password (from the `secrets.stackable.tech/format.compatibility.tls-pkcs12.password` volume attribute) was written to operator stdout in cleartext on every successful mount.

`tls_pkcs12_password` is now wrapped with the existing `Unloggable<T>` wrapper.

### Reproduction

Mount a `tls-pkcs12` volume with the password annotation:

```yaml
volumeClaimTemplate:
  metadata:
    annotations:
      secrets.stackable.tech/class: <class>
      secrets.stackable.tech/scope: pod
      secrets.stackable.tech/format: tls-pkcs12
      secrets.stackable.tech/format.compatibility.tls-pkcs12.password: "SUPERSECRET"
```

Before:
```
INFO ... issuing secret for Pod ... selector=SecretVolumeSelector { ... compat: CompatibilityOptions { tls_pkcs12_password: Some("SUPERSECRET") } ... }
```

After:
```
INFO ... issuing secret for Pod ... selector=SecretVolumeSelector { ... compat: CompatibilityOptions { tls_pkcs12_password: Some(<redacted>) } ... }
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
