### PR TITLE
feat: Support DCs in the subject DN of TLS certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Support configuring the name of the key in the ConfigMap/Secret, in which the PEM encoded CA certificate of the Truststore should be placed.
   This is e.g. needed to be able to use the generated Secret within an OpenShift Ingress ([#679]).
-- Support adding domain components to the subject DN of TLS certificates with the volume annotaton
+- Support adding domain components to the subject DN of TLS certificates with the volume annotation
   `secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn` ([#708]).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ All notable changes to this project will be documented in this file.
 
 - Support configuring the name of the key in the ConfigMap/Secret, in which the PEM encoded CA certificate of the Truststore should be placed.
   This is e.g. needed to be able to use the generated Secret within an OpenShift Ingress ([#679]).
+- Support adding domain components to the subject DN of TLS certificates with the volume annotaton
+  `secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn` ([#708]).
 
 ### Changed
 
 - Document Helm deployed RBAC permissions and remove unnecessary permissions ([#693]).
 
 [#693]: https://github.com/stackabletech/secret-operator/pull/693
+[#708]: https://github.com/stackabletech/secret-operator/pull/708
 
 ## [26.3.0] - 2026-03-16
 

--- a/docs/modules/secret-operator/pages/volume.adoc
+++ b/docs/modules/secret-operator/pages/volume.adoc
@@ -176,10 +176,17 @@ Jittering may be disabled by setting the jitter factor to 0.
 
 If set to `"true"`, the domain components of the Pod's fully qualified domain name (FQDN) are appended to the subject distinguished name (DN) of the TLS certificate.
 
-For example, the subject DN could look as follows:
+For example, the subject DN could look as follows for a StatefulSet Pod:
 
 ```
 CN=generated certificate for pod, DC=my-pod-0, DC=my-statefulset-service, DC=my-namespace, DC=svc, DC=cluster, DC=local
+```
+
+The service name is not part of the domain components if the Pod spec does not contain a subdomain, e.g. for Deployments and Jobs:
+
+```
+CN=generated certificate for pod, DC=my-job-pod-7c5xx, DC=my-namespace, DC=svc, DC=cluster, DC=local
+
 ```
 
 [NOTE]
@@ -187,10 +194,11 @@ CN=generated certificate for pod, DC=my-pod-0, DC=my-statefulset-service, DC=my-
 Many products use the string representation of distinguished names as described in https://www.ietf.org/rfc/rfc4514.txt[RFC 4514{external-link-icon}^].
 The string representation starts with the last element of the sequence and moving backwards toward the first.
 
-The example above becomes:
+The examples above become:
 
 ```
 DC=local,DC=cluster,DC=svc,DC=my-namespace,DC=my-statefulset-service,DC=my-pod-0,CN=generated certificate for pod
+DC=local,DC=cluster,DC=svc,DC=my-namespace,DC=my-job-pod-7c5xx,CN=generated certificate for pod
 ```
 
 Attribute names can be in upper or lower case, with or without spaces between them.

--- a/docs/modules/secret-operator/pages/volume.adoc
+++ b/docs/modules/secret-operator/pages/volume.adoc
@@ -186,7 +186,6 @@ The service name is not part of the domain components if the Pod spec does not c
 
 ```
 CN=generated certificate for pod, DC=my-job-pod-7c5xx, DC=my-namespace, DC=svc, DC=cluster, DC=local
-
 ```
 
 [NOTE]

--- a/docs/modules/secret-operator/pages/volume.adoc
+++ b/docs/modules/secret-operator/pages/volume.adoc
@@ -166,6 +166,36 @@ For example, given a requested lifetime of 1 day and a jitter factor of 0.2, the
 
 Jittering may be disabled by setting the jitter factor to 0.
 
+=== `secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn`
+
+*Required*: false
+
+*Default value*: `"false"`
+
+*Backends*: xref:secretclass.adoc#backend-autotls[]
+
+If set to `"true"`, the domain components of the Pod's fully qualified domain name (FQDN) are appended to the subject distinguished name (DN) of the TLS certificate.
+
+For example, the subject DN could look as follows:
+
+```
+CN=generated certificate for pod, DC=my-pod-0, DC=my-statefulset-service, DC=my-namespace, DC=svc, DC=cluster, DC=local
+```
+
+[NOTE]
+====
+Many products use the string representation of distinguished names as described in https://www.ietf.org/rfc/rfc4514.txt[RFC 4514{external-link-icon}^].
+The string representation starts with the last element of the sequence and moving backwards toward the first.
+
+The example above becomes:
+
+```
+DC=local,DC=cluster,DC=svc,DC=my-namespace,DC=my-statefulset-service,DC=my-pod-0,CN=generated certificate for pod
+```
+
+Attribute names can be in upper or lower case, with or without spaces between them.
+====
+
 === `secrets.stackable.tech/backend.cert-manager.cert.lifetime`
 
 *Required*: false

--- a/rust/operator-binary/src/backend/auto_tls/mod.rs
+++ b/rust/operator-binary/src/backend/auto_tls/mod.rs
@@ -355,6 +355,21 @@ impl SecretBackend for TlsGenerate {
                     }
                 }
 
+                let domain_components = if selector.autotls_cert_domain_components_in_subject_dn {
+                    [
+                        Some(pod_info.pod_name.as_str()),
+                        pod_info.service_name.as_deref(),
+                        Some(&pod_info.namespace),
+                        Some("svc"),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .chain(pod_info.kubernetes_cluster_domain.split('.'))
+                    .collect()
+                } else {
+                    vec![]
+                };
+
                 let pod_cert = X509Builder::new()
                     .and_then(|mut x509| {
                         let subject_name = X509NameBuilder::new()
@@ -363,6 +378,12 @@ impl SecretBackend for TlsGenerate {
                                     Nid::COMMONNAME,
                                     "generated certificate for pod",
                                 )?;
+                                for domain_component in domain_components {
+                                    name.append_entry_by_nid(
+                                        Nid::DOMAINCOMPONENT,
+                                        domain_component,
+                                    )?;
+                                }
                                 Ok(name)
                             })?
                             .build();

--- a/rust/operator-binary/src/backend/mod.rs
+++ b/rust/operator-binary/src/backend/mod.rs
@@ -129,6 +129,13 @@ pub struct SecretVolumeSelector {
     )]
     pub autotls_cert_jitter_factor: f64,
 
+    #[serde(
+        rename = "secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn",
+        deserialize_with = "SecretVolumeSelector::deserialize_str_as_bool",
+        default
+    )]
+    pub autotls_cert_domain_components_in_subject_dn: bool,
+
     /// The TLS cert lifetime (when using the [`cert_manager`] backend).
     ///
     /// The format is documented in <https://docs.stackable.tech/home/nightly/concepts/duration>.
@@ -298,6 +305,16 @@ impl SecretVolumeSelector {
             <D::Error as serde::de::Error>::invalid_value(
                 Unexpected::Str(&str),
                 &"a string containing a f64",
+            )
+        })
+    }
+
+    fn deserialize_str_as_bool<'de, D: Deserializer<'de>>(de: D) -> Result<bool, D::Error> {
+        let str = String::deserialize(de)?;
+        str.parse().map_err(|_| {
+            <D::Error as serde::de::Error>::invalid_value(
+                Unexpected::Str(&str),
+                &"a string containing a boolean",
             )
         })
     }

--- a/rust/operator-binary/src/backend/mod.rs
+++ b/rust/operator-binary/src/backend/mod.rs
@@ -132,7 +132,7 @@ pub struct SecretVolumeSelector {
     /// If set to `"true"`, the domain components of the Pod's fully qualified domain name (FQDN)
     /// are appended to the subject distinguished name (DN) of the TLS certificate.
     ///
-    /// For example, the subject DN could look as follows:
+    /// For example, the subject DN could look as follows for a StatefulSet Pod:
     ///
     /// `CN=generated certificate for pod, DC=my-pod-0, DC=my-statefulset-service, DC=my-namespace, DC=svc, DC=cluster, DC=local`
     #[serde(

--- a/rust/operator-binary/src/backend/mod.rs
+++ b/rust/operator-binary/src/backend/mod.rs
@@ -129,6 +129,12 @@ pub struct SecretVolumeSelector {
     )]
     pub autotls_cert_jitter_factor: f64,
 
+    /// If set to `"true"`, the domain components of the Pod's fully qualified domain name (FQDN)
+    /// are appended to the subject distinguished name (DN) of the TLS certificate.
+    ///
+    /// For example, the subject DN could look as follows:
+    ///
+    /// `CN=generated certificate for pod, DC=my-pod-0, DC=my-statefulset-service, DC=my-namespace, DC=svc, DC=cluster, DC=local`
     #[serde(
         rename = "secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn",
         deserialize_with = "SecretVolumeSelector::deserialize_str_as_bool",

--- a/rust/operator-binary/src/backend/pod_info.rs
+++ b/rust/operator-binary/src/backend/pod_info.rs
@@ -104,7 +104,9 @@ pub enum FromPodError {
 #[derive(Debug)]
 pub struct PodInfo {
     pub pod_ips: Vec<IpAddr>,
+    pub pod_name: String,
     pub service_name: Option<String>,
+    pub namespace: String,
     pub node_name: String,
     pub node_ips: Vec<IpAddr>,
     pub listener_addresses: Option<ListenerAddresses>,
@@ -119,6 +121,8 @@ impl PodInfo {
         scopes: &[SecretScope],
     ) -> Result<Self, FromPodError> {
         use from_pod_error::*;
+        let pod_name = pod.metadata.name.clone().context(NoPodNameSnafu)?;
+        let namespace = pod.metadata.namespace.clone().context(NoNamespaceSnafu)?;
         let node_name = pod
             .spec
             .as_ref()
@@ -150,7 +154,9 @@ impl PodInfo {
                         .context(from_pod_error::IllegalAddressSnafu { address: ip })
                 })
                 .collect::<Result<_, _>>()?,
+            pod_name,
             service_name: pod.spec.as_ref().and_then(|spec| spec.subdomain.clone()),
+            namespace,
             node_name,
             node_ips: node
                 .status

--- a/tests/templates/kuttl/tls/10_consumer.yaml.j2
+++ b/tests/templates/kuttl/tls/10_consumer.yaml.j2
@@ -22,7 +22,7 @@ spec:
               CERT_NAME=tls.crt
               CA_NAME=ca.crt
 {% endif %}
-            - |
+
               set -euo pipefail
               ls -la /stackable/tls-3d
               ls -la /stackable/tls-42h
@@ -67,11 +67,18 @@ spec:
               assert_trusted_roots_contain "cert 4b"
               assert_trusted_roots_contain "cert 5"
               assert_trusted_roots_contain "cert 6"
+
+              echo Test subject DN with domain components
+
+              openssl x509 -in /stackable/tls-domain-components/tls.crt -subject -noout | \
+                  grep "subject=CN=generated certificate for pod, DC=tls-consumer-.*, DC=$NAMESPACE, DC=svc, DC=.*"
           volumeMounts:
             - mountPath: /stackable/tls-3d
               name: tls-3d
             - mountPath: /stackable/tls-42h
               name: tls-42h
+            - mountPath: /stackable/tls-domain-components
+              name: tls-domain-components
       volumes:
         - name: tls-3d
           ephemeral:
@@ -104,6 +111,21 @@ spec:
                   secrets.stackable.tech/format.tls-pem.cert-name: custom-tls.crt
                   secrets.stackable.tech/format.tls-pem.ca-name: custom-ca.crt
 {% endif %}
+              spec:
+                storageClassName: secrets.stackable.tech
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: "1"
+        - name: tls-domain-components
+          ephemeral:
+            volumeClaimTemplate:
+              metadata:
+                annotations:
+                  secrets.stackable.tech/class: tls-$NAMESPACE
+                  secrets.stackable.tech/scope: pod
+                  secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn: "true"
               spec:
                 storageClassName: secrets.stackable.tech
                 accessModes:

--- a/tests/templates/kuttl/tls/10_consumer.yaml.j2
+++ b/tests/templates/kuttl/tls/10_consumer.yaml.j2
@@ -68,7 +68,7 @@ spec:
               assert_trusted_roots_contain "cert 5"
               assert_trusted_roots_contain "cert 6"
 
-              echo Test subject DN with domain components
+              echo "Test subject DN with domain components"
 
               openssl x509 -in /stackable/tls-domain-components/tls.crt -subject -noout | \
                   grep "subject=CN=generated certificate for pod, DC=tls-consumer-.*, DC=$NAMESPACE, DC=svc, DC=.*"


### PR DESCRIPTION
## Description

Support adding domain components to the subject DN of TLS certificates with the volume annotation `secrets.stackable.tech/backend.autotls.cert.domain-components-in-subject-dn`

Part of #617 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] CRD changes approved: stackabletech/decisions#81
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
- [x] Links to generated (nightly) docs added: https://docs.stackable.tech/home/nightly/secret-operator/volume/#_secrets_stackable_techbackend_autotls_cert_domain_components_in_subject_dn
- [x] Release note snippet added: https://github.com/stackabletech/secret-operator/pull/708#issuecomment-4799339007

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
