### PR TITLE
docs: document CA-only SecretClass for TLS server verification

### DIFF
--- a/docs/modules/secret-operator/pages/secretclass.adoc
+++ b/docs/modules/secret-operator/pages/secretclass.adoc
@@ -386,6 +386,8 @@ This backend can be used to mount `Secret` across namespaces into pods. The `Sec
 
 Each field in this `Secret` is mapped to one file. It is suggested these `Secret` objects should follow one of the xref:#format[formats defined in this document].
 
+TIP: This backend is also the right choice when you want to provide an existing CA certificate for xref:concepts:tls-server-verification.adoc[TLS server verification], for example to verify an LDAP or S3 server. Put the CA certificate into a `Secret` under the key `ca.crt` and reference it from a `k8sSearch` SecretClass. Unlike the xref:#backend-autotls[`autoTls`] backend, this does not require the CA's private key.
+
 In the example below, given the three object definitions for a `Pod`, a `SecretClass` and a `Secret`, the operator will first read the Pod's volume attributes then look up the secret class. The `k8sSearch` backend will look up the Secret object labeled with `secrets.stackable.tech/class: admin-credentials-class` (the name of the secret class) and mount the fields of the Secret as files into the container at the specified mount point (`/credentials`).
 Please note that the contents in the volume will not update when the Secret content changes. A Pod restart is needed to refresh the Secret contents on disk.
 


### PR DESCRIPTION
## Description

Sibling to
* https://github.com/stackabletech/documentation/pull/860
* https://github.com/stackabletech/nifi-operator/pull/949

Resulting from the same thread.

Describes how to provide a CA for _verification_ and not for creation of actual certificates.