### PR TITLE
docs: clarify kubelet state dir on Tanzu deployments

### DIFF
--- a/docs/modules/secret-operator/pages/installation.adoc
+++ b/docs/modules/secret-operator/pages/installation.adoc
@@ -62,5 +62,7 @@ In case you are encountering the mentioned error (or secret-operator does not wo
 
 === VMware Tanzu
 
-VMware Tanzu uses a non-standard Kubelet state directory. Installing secret-operator on Tanzu requires the argument
-`--set csiNodeDriver.kubeletDir=/var/vcap/data/kubelet` to be added to the `helm install` command.
+Whether Tanzu uses a non-standard Kubelet state directory depends on the variant.
+BOSH-deployed clusters (Tanzu Kubernetes Grid Integrated Edition, formerly PKS) place it under `/var/vcap`, so installing secret-operator there requires the argument `--set csiNodeDriver.kubeletDir=/var/vcap/data/kubelet` to be added to the `helm install` command.
+Standard clusters (Tanzu Kubernetes Grid and vSphere with Tanzu) use the default `/var/lib/kubelet` and need no override.
+If unsure, check the actual directory on a node before overriding.


### PR DESCRIPTION
## Description


Clarifies under which conditions VMware Tanzu deployments require a custom `csiNodeDriver.kubeletDir`

(see https://github.com/stackabletech/listener-operator/pull/403)