### PR TITLE
chore: Namespace the CSI Helm defined templates

### DIFF
--- a/deploy/helm/secret-operator/templates/_local_helpers.tpl
+++ b/deploy/helm/secret-operator/templates/_local_helpers.tpl
@@ -1,13 +1,13 @@
 {{/*
 Expand the image name for csi-provisioner
 */}}
-{{- define "csi-provisioner.image" -}}
+{{- define "secret-operator.csi-provisioner.image" -}}
 {{- printf "%s/csi-provisioner:%s" (.Values.csiNodeDriver.externalProvisioner.image.repository | default (printf "%s/sig-storage" .Values.image.repository)) .Values.csiNodeDriver.externalProvisioner.image.tag }}
 {{- end }}
 
 {{/*
 Expand the image name for csi-node-driver-registrar
 */}}
-{{- define "csi-node-driver-registrar.image" -}}
+{{- define "secret-operator.csi-node-driver-registrar.image" -}}
 {{- printf "%s/csi-node-driver-registrar:%s" (.Values.csiNodeDriver.nodeDriverRegistrar.image.repository | default (printf "%s/sig-storage" .Values.image.repository)) .Values.csiNodeDriver.nodeDriverRegistrar.image.tag }}
 {{- end }}

--- a/deploy/helm/secret-operator/templates/csi-node-driver-daemonset.yaml
+++ b/deploy/helm/secret-operator/templates/csi-node-driver-daemonset.yaml
@@ -108,7 +108,7 @@ spec:
               mountPath: /tmp
 
         - name: external-provisioner
-          image: "{{ include "csi-provisioner.image" . }}"
+          image: "{{ include "secret-operator.csi-provisioner.image" . }}"
           imagePullPolicy: {{ .Values.csiNodeDriver.externalProvisioner.image.pullPolicy }}
           resources:
             {{ .Values.csiNodeDriver.externalProvisioner.resources | toYaml | nindent 12 }}
@@ -121,7 +121,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: "{{ include "csi-node-driver-registrar.image" . }}"
+          image: "{{ include "secret-operator.csi-node-driver-registrar.image" . }}"
           imagePullPolicy: {{ .Values.csiNodeDriver.nodeDriverRegistrar.image.pullPolicy }}
           resources:
             {{ .Values.csiNodeDriver.nodeDriverRegistrar.resources | toYaml | nindent 12 }}


### PR DESCRIPTION
## Description

The previous name could collide with the identically named thing in listener-operator. This could cause issues when used in an umbrella Chart.

https://github.com/stackabletech/issues/issues/882
